### PR TITLE
feat: simplify feed creation flows

### DIFF
--- a/app/web/api/v1/create_feed.rb
+++ b/app/web/api/v1/create_feed.rb
@@ -9,7 +9,7 @@ module Html2rss
       module V1
         ##
         # Creates stable feed records from authenticated API requests.
-        module CreateFeed # rubocop:disable Metrics/ModuleLength
+        module CreateFeed
           FEED_ATTRIBUTE_KEYS =
             %i[id name url feed_token public_url json_public_url created_at updated_at].freeze
           FEED_METADATA_KEYS =
@@ -41,6 +41,8 @@ module Html2rss
 
             private
 
+            # @param request [Rack::Request]
+            # @return [Hash]
             def require_account(request)
               account = Auth.authenticate(request)
               raise Html2rss::Web::UnauthorizedError, 'Authentication required' unless account
@@ -48,17 +50,24 @@ module Html2rss
               account
             end
 
+            # @param request [Rack::Request]
+            # @param account [Hash]
+            # @return [Html2rss::Web::Api::V1::FeedMetadata::CreateParams]
             def build_create_params(request, account)
               url = validated_url(request_params(request)['url'], account)
               FeedMetadata::CreateParams.new(url:, name: FeedMetadata.site_title_for(url))
             end
 
+            # @param request [Rack::Request]
+            # @return [Hash]
             def request_params(request)
               return request.params unless json_request?(request)
 
               request.GET.merge(parsed_json_body(request))
             end
 
+            # @param request [Rack::Request]
+            # @return [Hash]
             def parsed_json_body(request)
               raw_body = request.body.read
               request.body.rewind
@@ -72,6 +81,8 @@ module Html2rss
               raise Html2rss::Web::BadRequestError, 'Invalid JSON payload'
             end
 
+            # @param request [Rack::Request]
+            # @return [Boolean]
             def json_request?(request)
               request.env['CONTENT_TYPE'].to_s.include?('application/json')
             end

--- a/app/web/routes/api_v1/feed_routes.rb
+++ b/app/web/routes/api_v1/feed_routes.rb
@@ -20,8 +20,6 @@ module Html2rss
                 router.post do
                   JSON.generate(Api::V1::CreateFeed.call(router))
                 end
-
-                raise NotFoundError
               end
             end
           end


### PR DESCRIPTION
TODO:
- [x] encode Strategy "auto" by default, which selects for  best ux automatically 
- [x] in future: add Botasaurus strategy (separate change)
- [ ] ?? on feed result page, enable user to manually 'upgrade' to / try the browserless strategy
- [ ] allow selection of strategy (keep it out of primary user journey path, i.e. "advanced" expander in a screen)
- [ ] mirror cli api to web? no reinvent wheel, exposes all the config options? "auto" feeds on demand with hmac'ed url?

## Summary
This branch now includes both the SPA route-flow work and a hard-cutover API contract migration so frontend state is driven by structured payloads instead of message parsing.

### 1) API contract cutover (backend)
- `POST /api/v1/feeds` now accepts only `{ "url": ... }` for create flow usage.
- Structured failure envelope is standardized via `Api::V1::Contract.failure_payload` with:
  - `kind` (`auth|input|network|server`)
  - `code`
  - `retryable`
  - `next_action`
  - `retry_action`
  - `next_strategy` only when explicitly applicable
- Added typed status endpoint:
  - `GET /api/v1/feeds/:token/status`
  - returns explicit conversion state fields:
    - `readiness_phase`
    - `preview_status`
    - `warnings[]`
- Removed message-text branching for control flow decisions and replaced with typed mapping/classification.
- Added explicit typed errors for policy/health handling:
  - `AutoSourceDisabledError`
  - `HealthCheckFailedError`

### 2) Frontend flow simplification (no strategy UI/control path)
- Route-driven SPA flow stabilized (`/create`, `/token`, `/result/:feedToken`) with state recovery support.
- `useFeedConversion` now consumes structured API metadata for auth/retry/readiness decisions.
- Removed strategy-driven UX coupling in app flow:
  - deleted `useStrategies` hook usage from app path
  - no strategy selector in create flow
- Canonical API parsing tightened to contract fields used by the backend cutover.
- Result rendering now uses explicit readiness/degraded metadata rather than inference.

### 3) Token/storage cleanup
- Removed legacy localStorage token migration shim from `useAccessToken`.
- Canonical token behavior is now session-storage-first with existing in-memory fallback.
- Updated tests to enforce session-only canonical behavior.

### 4) OpenAPI + generated client sync
- Updated `public/openapi.yaml` to match create/status + error envelope contract.
- Regenerated frontend API artifacts:
  - `frontend/src/api/generated/index.ts`
  - `frontend/src/api/generated/sdk.gen.ts`
  - `frontend/src/api/generated/types.gen.ts`

### 5) Reliability / observability / infra hardening in branch
- DSN-gated Sentry breadcrumb/log wiring and related test coverage.
- Feed responder/renderer contract adjustments for structured outcomes.
- Build/lint determinism improvement:
  - `make lint-ruby` now uses configurable RuboCop flags with cache disabled by default in this repo path to avoid cache-only exit-2 behavior.

## Notes
- This is a hard-cutover contract update for create/status and structured failures.
- `/api/v1/strategies` endpoint compatibility is preserved externally, but app flow no longer depends on strategy controls.
