### PR TITLE
ci: use gha cache and fix release-please triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,7 +165,6 @@ jobs:
           load: true
           tags: html2rss/web
           cache-from: type=gha
-          # No cache-to here; we only want to read the image built in the previous job
 
       - name: Run Docker smoke test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,26 +126,24 @@ jobs:
       - ruby
       - openapi
       - frontend
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-
+      - uses: docker/setup-buildx-action@v4
       - name: Build Docker smoke image
-        run: docker build -t html2rss/web -f Dockerfile .
-
-      - name: Export Docker smoke image
-        run: docker save html2rss/web -o /tmp/html2rss-web-smoke-image.tar
-
-      - name: Upload Docker smoke image
-        uses: actions/upload-artifact@v7
+        uses: docker/build-push-action@v7
         with:
-          name: docker-smoke-image
-          path: /tmp/html2rss-web-smoke-image.tar
-          retention-days: 1
+          context: .
+          load: true
+          tags: html2rss/web
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   docker-test:
     needs:
       - docker-build-smoke-image
+    if: github.event_name != 'pull_request' || !startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -158,14 +156,16 @@ jobs:
         with:
           bundler-cache: true
 
-      - name: Download Docker smoke image
-        uses: actions/download-artifact@v8
-        with:
-          name: docker-smoke-image
-          path: /tmp
+      - uses: docker/setup-buildx-action@v4
 
-      - name: Load Docker smoke image
-        run: docker load -i /tmp/html2rss-web-smoke-image.tar
+      - name: Build Docker smoke image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          load: true
+          tags: html2rss/web
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
       - name: Run Docker smoke test
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,14 +158,14 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
-      - name: Build Docker smoke image
+      - name: Load Docker smoke image from cache
         uses: docker/build-push-action@v7
         with:
           context: .
           load: true
           tags: html2rss/web
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # No cache-to here; we only want to read the image built in the previous job
 
       - name: Run Docker smoke test
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,14 +154,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
         env:
@@ -174,8 +166,8 @@ jobs:
             BUILD_TAG=${{ env.RELEASE_VERSION }}
             GIT_SHA=${{ needs.guard.outputs.target_sha }}
           platforms: linux/amd64,linux/arm64
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           provenance: true
           sbom: true
           labels: |
@@ -187,11 +179,6 @@ jobs:
             org.opencontainers.image.title=html2rss-web
             org.opencontainers.image.url=https://github.com/${{ github.repository }}/releases/tag/${{ env.RELEASE_TAG }}
             org.opencontainers.image.version=${{ env.RELEASE_VERSION }}
-
-      - name: Move updated cache into place
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
 
       - name: Summarize published image tags
         run: |


### PR DESCRIPTION
This pull request updates the Docker build and caching strategy in the CI and release GitHub Actions workflows. The main improvements are switching to GitHub Actions (GHA) cache storage for Docker layers, simplifying the build and test steps, and ensuring certain jobs are skipped for release-please branches.

**CI Workflow improvements:**

* Switched Docker image caching from manual artifact upload/download to using `docker/build-push-action` with GHA cache storage, streamlining the build and test process (`.github/workflows/ci.yml`). [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR129-R146) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL161-R168)
* Added job conditions to skip Docker build and test steps for release-please branches in pull requests, reducing unnecessary CI runs (`.github/workflows/ci.yml`). [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR129-R146) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL161-R168)

**Release Workflow improvements:**

* Removed local Docker cache management and replaced with GHA cache for Docker buildx, simplifying cache handling and improving cache sharing across runners (`.github/workflows/release.yml`). [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L157-L164) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L177-R170) [[3]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L191-L195)

These changes make the workflows more efficient, easier to maintain, and better leverage GitHub Actions built-in caching for Docker images.