### PR TITLE
ci: automate openapi artifact regeneration on release PRs

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -4,7 +4,19 @@
       "release-type": "ruby",
       "package-name": "html2rss-web",
       "version-file": "config/version.rb",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "frontend/package.json",
+          "jsonpath": "$.version"
+        },
+        "public/openapi.yaml",
+        "frontend/src/api/generated/client.gen.ts",
+        "frontend/src/api/generated/sdk.gen.ts",
+        "frontend/src/api/generated/types.gen.ts",
+        "frontend/src/api/generated/index.ts"
+      ]
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -71,7 +73,25 @@ jobs:
         working-directory: frontend
 
       - name: Verify generated OpenAPI spec and client are up to date
+        id: verify
         run: make openapi-verify
+        continue-on-error: ${{ startsWith(github.head_ref, 'release-please--') }}
+
+      - name: Regenerate and commit OpenAPI artifacts on release PRs
+        if: steps.verify.outcome == 'failure' && startsWith(github.head_ref, 'release-please--')
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          
+          make openapi
+          make openapi-client
+          
+          git add public/openapi.yaml frontend/src/api/generated/
+          git commit -m "chore: regenerate openapi spec and client for version bump"
+          git push
+          
+          echo "## OpenAPI artifacts regenerated" >> "$GITHUB_STEP_SUMMARY"
+          echo "Version bump detected; OpenAPI spec and frontend client have been regenerated and committed." >> "$GITHUB_STEP_SUMMARY"
 
       - name: Lint OpenAPI contract
         run: make openapi-lint


### PR DESCRIPTION
This pull request updates the release and CI automation to better manage versioning and OpenAPI artifact generation, especially during release PRs. The changes ensure that frontend and OpenAPI artifacts are kept in sync with backend releases and automates regeneration and committing of these artifacts when needed.

**Release automation enhancements:**

* [`.github/release-please-config.json`](diffhunk://#diff-b4c6ab25197e992b430b71d65743b6459f06f248f7c6b3364f1942e40d9f0039L7-R19): Configured `release-please` to update additional files on release, including `frontend/package.json` (version), `public/openapi.yaml`, and generated frontend API client files, ensuring all relevant artifacts are versioned together.

**CI workflow improvements:**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR52-R53): Updated the `actions/checkout` step to use a custom token if available, improving permissions for CI/CD workflows.
* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR76-R94): Enhanced the OpenAPI verification step to allow release PRs to proceed even if OpenAPI artifacts are out of date, and added a new step that automatically regenerates and commits OpenAPI spec and client files during release PRs when needed. This reduces manual intervention and ensures that generated artifacts are always up to date in release branches.