### PR TITLE
ci: harden openapi auto-regeneration and streamline config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -11,11 +11,7 @@
           "path": "frontend/package.json",
           "jsonpath": "$.version"
         },
-        "public/openapi.yaml",
-        "frontend/src/api/generated/client.gen.ts",
-        "frontend/src/api/generated/sdk.gen.ts",
-        "frontend/src/api/generated/types.gen.ts",
-        "frontend/src/api/generated/index.ts"
+        "public/openapi.yaml"
       ]
     }
   }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,14 @@ jobs:
 
   openapi:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -87,11 +91,16 @@ jobs:
           make openapi-client
           
           git add public/openapi.yaml frontend/src/api/generated/
-          git commit -m "chore: regenerate openapi spec and client for version bump"
-          git push
           
-          echo "## OpenAPI artifacts regenerated" >> "$GITHUB_STEP_SUMMARY"
-          echo "Version bump detected; OpenAPI spec and frontend client have been regenerated and committed." >> "$GITHUB_STEP_SUMMARY"
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "chore: regenerate openapi spec and client for version bump"
+            git push origin ${{ github.head_ref }}
+            
+            echo "## OpenAPI artifacts regenerated" >> "$GITHUB_STEP_SUMMARY"
+            echo "Version bump detected; OpenAPI spec and frontend client have been regenerated and committed." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Lint OpenAPI contract
         run: make openapi-lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
-          ref: ${{ github.head_ref }}
+          ref: ${{ (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--')) && github.head_ref || github.sha }}
           fetch-depth: 0
 
       - uses: ruby/setup-ruby@v1


### PR DESCRIPTION
This pull request updates the OpenAPI release and CI workflow to improve automation and commit handling. The most significant changes focus on how OpenAPI artifacts are managed and committed during the CI process.

**OpenAPI artifact management and CI workflow improvements:**

* The CI workflow now checks for changes in OpenAPI artifacts before committing and pushing. If there are no changes after regeneration, it skips the commit and push step, preventing unnecessary commits.
* The OpenAPI job in the CI workflow now explicitly sets `contents: write` permissions and ensures the correct git reference is checked out, which is important for release automation and branch consistency.

**Release configuration:**

* The `.github/release-please-config.json` file has been updated to only include `public/openapi.yaml` in the release process for OpenAPI artifacts, removing the frontend generated client files from direct release tracking.