### PR TITLE
fix(ci): robustly parse release tags and align config

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -3,6 +3,7 @@
     ".": {
       "release-type": "ruby",
       "package-name": "html2rss-web",
+      "include-component-in-tag": false,
       "version-file": "config/version.rb",
       "changelog-path": "CHANGELOG.md",
       "extra-files": [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,11 @@ jobs:
       - name: Compute Docker tags
         id: tags
         run: |
-          release_version="${RELEASE_TAG#v}"
+          # Extract the version part (e.g., html2rss-web/v1.1.0 -> v1.1.0, or v1.1.0 -> v1.1.0)
+          clean_tag="${RELEASE_TAG##*/}"
+          # Remove leading 'v' if present (e.g., v1.1.0 -> 1.1.0)
+          release_version="${clean_tag#v}"
+
           echo "RELEASE_VERSION=${release_version}" >> "$GITHUB_ENV"
           major="${release_version%%.*}"
           {


### PR DESCRIPTION
- Strips component prefix from Docker tags in release workflow.
- Disables component prefix in release-please-config.json to match html2rss/html2rss.
- Ensures compatibility with legacy prefixed tags and new clean tags.