### PR TITLE
chore(ci): fix bump-version workflow issues

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Assert main branch
         run: |
@@ -45,7 +46,7 @@ jobs:
         uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
-          disable-releases: true
+          disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR fixes issues in the new bump-version workflow:
1. Replaces the unexpected disable-releases input for release-drafter with disable-releaser.
2. Prevents Duplicate Header: Authorization Git issues by setting persist-credentials: false on actions/checkout.