### PR TITLE
chore: bypass obsolete RELEASE_PLEASE_TOKEN in bump-version workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -112,7 +112,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.BUMP_VERSION_TOKEN || github.token }}
+          token: ${{ secrets.BUMP_VERSION_TOKEN || github.token }}
           commit-message: "chore: bump version to v${{ steps.perform_bump.outputs.new_version }}"
           branch: "bump-version/v${{ steps.perform_bump.outputs.new_version }}"
           title: "chore: bump version to v${{ steps.perform_bump.outputs.new_version }}"


### PR DESCRIPTION
This pull request makes a small update to the version bump workflow. The change ensures that only the `BUMP_VERSION_TOKEN` or the default GitHub token is used for authentication when creating a pull request, removing the use of the `RELEASE_PLEASE_TOKEN`.

* Updated the `bump-version.yml` workflow to use only `BUMP_VERSION_TOKEN` or `github.token` for the pull request creation step, removing `RELEASE_PLEASE_TOKEN` from the token selection.