### PR TITLE
feat: implement rate limiting, cache bounds, and standard timeout error codes

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -54,6 +54,7 @@ module Html2rss
       def development? = self.class.development?
       opts.merge!(check_dynamic_arity: false, check_arity: :warn)
       use RequestContextMiddleware
+      use RateLimiter
       use Rack::Cache, metastore: 'file:./tmp/rack-cache-meta', entitystore: 'file:./tmp/rack-cache-body',
                        verbose: development?
 

--- a/app/web/config/flags.rb
+++ b/app/web/config/flags.rb
@@ -4,7 +4,7 @@ module Html2rss
   module Web
     ##
     # Typed feature flag registry and runtime access.
-    module Flags
+    module Flags # rubocop:disable Metrics/ModuleLength
       # @!attribute [r] name
       #   @return [Symbol]
       # @!attribute [r] env_key
@@ -37,11 +37,71 @@ module Html2rss
           type: :integer,
           default: 3,
           validator: ->(value) { value >= 1 }
+        ),
+        feeds_cache_max_size: Definition.new(
+          name: :feeds_cache_max_size,
+          env_key: 'FEEDS_CACHE_MAX_SIZE',
+          type: :integer,
+          default: 500,
+          validator: ->(value) { value >= 1 }
+        ),
+        rate_limit_enabled: Definition.new(
+          name: :rate_limit_enabled,
+          env_key: 'RATE_LIMIT_ENABLED',
+          type: :boolean,
+          default: -> { ENV.fetch('RACK_ENV', 'development') != 'test' },
+          validator: nil
+        ),
+        rate_limit_max_requests: Definition.new(
+          name: :rate_limit_max_requests,
+          env_key: 'RATE_LIMIT_MAX_REQUESTS',
+          type: :integer,
+          default: 60,
+          validator: ->(value) { value >= 1 }
+        ),
+        rate_limit_window_seconds: Definition.new(
+          name: :rate_limit_window_seconds,
+          env_key: 'RATE_LIMIT_WINDOW_SECONDS',
+          type: :integer,
+          default: 60,
+          validator: ->(value) { value >= 1 }
+        ),
+        retry_after_timeout_seconds: Definition.new(
+          name: :retry_after_timeout_seconds,
+          env_key: 'RETRY_AFTER_TIMEOUT_SECONDS',
+          type: :integer,
+          default: 300,
+          validator: ->(value) { value >= 1 }
         )
       }.freeze
-      MANAGED_ENV_PREFIXES = %w[AUTO_SOURCE_ ASYNC_FEED_REFRESH_].freeze
+      MANAGED_ENV_PREFIXES = %w[AUTO_SOURCE_ ASYNC_FEED_REFRESH_ FEEDS_CACHE_ RATE_LIMIT_ RETRY_AFTER_].freeze
 
       class << self
+        # @return [Boolean]
+        def rate_limit_enabled?
+          fetch(:rate_limit_enabled)
+        end
+
+        # @return [Integer]
+        def rate_limit_max_requests
+          fetch(:rate_limit_max_requests)
+        end
+
+        # @return [Integer]
+        def rate_limit_window_seconds
+          fetch(:rate_limit_window_seconds)
+        end
+
+        # @return [Integer]
+        def retry_after_timeout_seconds
+          fetch(:retry_after_timeout_seconds)
+        end
+
+        # @return [Integer]
+        def feeds_cache_max_size
+          fetch(:feeds_cache_max_size)
+        end
+
         # @return [Boolean]
         def auto_source_enabled?
           fetch(:auto_source_enabled)

--- a/app/web/errors/error_responder.rb
+++ b/app/web/errors/error_responder.rb
@@ -32,7 +32,7 @@ module Html2rss
           response.status = status
 
           if status == 429
-            response['Retry-After'] ||= '60'
+            response['Retry-After'] ||= Flags.rate_limit_window_seconds.to_s
           elsif [503, 504].include?(status)
             response['Retry-After'] = Flags.retry_after_timeout_seconds.to_s
           end

--- a/app/web/errors/error_responder.rb
+++ b/app/web/errors/error_responder.rb
@@ -4,7 +4,7 @@ module Html2rss
   module Web
     ##
     # Centralized error rendering for API and XML endpoints.
-    module ErrorResponder
+    module ErrorResponder # rubocop:disable Metrics/ModuleLength
       API_ROOT_PATH = '/api/v1'
       EXTRACTION_EMPTY_CODE = 'EXTRACTION_EMPTY'
       EXTRACTION_EMPTY_MESSAGE = 'We could not extract feed items from this page yet. ' \
@@ -20,14 +20,23 @@ module Html2rss
       SERVER_META = { kind: 'server', retryable: false, next_action: 'none', retry_action: 'none' }.freeze
       RETRY_META = { retryable: true, next_action: 'retry', retry_action: 'primary' }.freeze
 
-      class << self
+      class << self # rubocop:disable Metrics/ClassLength
         # @param request [Rack::Request]
         # @param response [Rack::Response]
         # @param error [StandardError]
         # @return [String]
+        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def respond(request:, response:, error:)
+          status = resolve_status(error)
           code = resolve_error_code(error)
-          response.status = resolve_status(error)
+          response.status = status
+
+          if status == 429
+            response['Retry-After'] ||= '60'
+          elsif [503, 504].include?(status)
+            response['Retry-After'] = Flags.retry_after_timeout_seconds.to_s
+          end
+
           emit_error_event(error, code, response.status)
           write_internal_error_log(request, error)
 
@@ -39,6 +48,7 @@ module Html2rss
 
           render_xml_error(response, error)
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         private
 
@@ -62,25 +72,36 @@ module Html2rss
         end
 
         def resolve_error_code(error)
-          if extraction_empty_failure?(error)
-            EXTRACTION_EMPTY_CODE
-          else
-            (error.respond_to?(:code) ? error.code : INTERNAL_ERROR_CODE)
+          case error
+          when ->(e) { extraction_empty_failure?(e) } then EXTRACTION_EMPTY_CODE
+          when TooManyRequestsError then 'TOO_MANY_REQUESTS'
+          when ServiceUnavailableError, ->(e) { server_timeout?(e) } then 'SERVICE_UNAVAILABLE'
+          when GatewayTimeoutError, ->(e) { gateway_timeout?(e) } then 'GATEWAY_TIMEOUT'
+          else error.respond_to?(:code) ? error.code : INTERNAL_ERROR_CODE
           end
         end
 
         def resolve_status(error)
-          if extraction_empty_failure?(error)
-            422
-          else
-            (error.respond_to?(:status) ? error.status : 500)
+          case error
+          when ->(e) { extraction_empty_failure?(e) } then 422
+          when TooManyRequestsError then 429
+          when ServiceUnavailableError, ->(e) { server_timeout?(e) } then 503
+          when GatewayTimeoutError, ->(e) { gateway_timeout?(e) } then 504
+          else error.respond_to?(:status) ? error.status : 500
           end
         end
 
         def client_message_for(error)
-          return EXTRACTION_EMPTY_MESSAGE if extraction_empty_failure?(error)
-
-          error.is_a?(HttpError) ? error.message : HttpError::DEFAULT_MESSAGE
+          case error
+          when ->(e) { extraction_empty_failure?(e) } then EXTRACTION_EMPTY_MESSAGE
+          when TooManyRequestsError then 'Too many requests. Please wait before retrying.'
+          when ServiceUnavailableError, ->(e) { server_timeout?(e) }
+            'The server is too busy or the request timed out. Please try again later.'
+          when GatewayTimeoutError, ->(e) { gateway_timeout?(e) }
+            'The target website took too long to respond. Please try again later.'
+          else
+            error.is_a?(HttpError) ? error.message : HttpError::DEFAULT_MESSAGE
+          end
         end
 
         def extraction_empty_failure?(error)
@@ -104,7 +125,21 @@ module Html2rss
         end
 
         def error_kind(error)
-          error_chain(error).any? { |e| NETWORK_ERRORS.include?(e.class) } ? 'network' : 'server'
+          if error.is_a?(TooManyRequestsError)
+            'client'
+          elsif error.is_a?(GatewayTimeoutError) || gateway_timeout?(error)
+            'network'
+          else
+            error_chain(error).any? { |e| NETWORK_ERRORS.include?(e.class) } ? 'network' : 'server'
+          end
+        end
+
+        def server_timeout?(error)
+          defined?(::Rack::Timeout::RequestTimeoutException) && error.is_a?(::Rack::Timeout::RequestTimeoutException)
+        end
+
+        def gateway_timeout?(error)
+          error.is_a?(Timeout::Error) || error.is_a?(Errno::ETIMEDOUT)
         end
 
         def error_chain(error)

--- a/app/web/errors/gateway_timeout_error.rb
+++ b/app/web/errors/gateway_timeout_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module Web
+    ##
+    # HTTP 504 error used when downstream request/fetch times out.
+    class GatewayTimeoutError < HttpError
+      DEFAULT_MESSAGE = 'Gateway timeout'
+      STATUS = 504
+      CODE = 'GATEWAY_TIMEOUT'
+    end
+  end
+end

--- a/app/web/errors/service_unavailable_error.rb
+++ b/app/web/errors/service_unavailable_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module Web
+    ##
+    # HTTP 503 error used when the server is temporarily overloaded or down.
+    class ServiceUnavailableError < HttpError
+      DEFAULT_MESSAGE = 'Service unavailable'
+      STATUS = 503
+      CODE = 'SERVICE_UNAVAILABLE'
+    end
+  end
+end

--- a/app/web/errors/too_many_requests_error.rb
+++ b/app/web/errors/too_many_requests_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module Web
+    ##
+    # HTTP 429 error used when client hits rate limits.
+    class TooManyRequestsError < HttpError
+      DEFAULT_MESSAGE = 'Too many requests'
+      STATUS = 429
+      CODE = 'TOO_MANY_REQUESTS'
+    end
+  end
+end

--- a/app/web/feeds/cache.rb
+++ b/app/web/feeds/cache.rb
@@ -58,9 +58,37 @@ module Html2rss
           end
 
           def write_entry(key, ttl_seconds, result)
+            prune_if_needed
             entries[key] = Entry.new(result: result, expires_at: Time.now.utc + normalize_ttl(ttl_seconds))
             SecurityLogger.log_cache_lifecycle('feeds_cache', 'write', key_hash: key_hash(key))
           end
+
+          # Prunes expired entries first. If still over the max limit, prunes entries expiring soonest.
+          #
+          # @return [void]
+          # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
+          def prune_if_needed
+            max = Flags.feeds_cache_max_size
+            return if entries.size < max
+
+            now = Time.now.utc
+            entries.each_key do |key|
+              entry = entries[key]
+              entries.delete(key) if entry && now >= entry.expires_at
+            end
+
+            return if entries.size < max
+
+            candidates = entries.keys.map { |k| [k, entries[k]&.expires_at] }.select { |_, exp| exp }
+            candidates.sort_by! { |_, exp| exp }
+
+            target_size = (max * 0.9).to_i
+            num_to_delete = entries.size - target_size
+            return if num_to_delete <= 0
+
+            candidates.first(num_to_delete).each { |item| entries.delete(item[0]) }
+          end
+          # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
           # @param cacheable [Boolean, Proc]
           # @param result [Html2rss::Web::Feeds::Contracts::RenderResult]

--- a/app/web/feeds/cache.rb
+++ b/app/web/feeds/cache.rb
@@ -72,14 +72,16 @@ module Html2rss
             return if entries.size < max
 
             now = Time.now.utc
-            entries.each_key do |key|
-              entry = entries[key]
+            entries.each_pair do |key, entry|
               entries.delete(key) if entry && now >= entry.expires_at
             end
 
             return if entries.size < max
 
-            candidates = entries.keys.map { |k| [k, entries[k]&.expires_at] }.select { |_, exp| exp }
+            candidates = []
+            entries.each_pair do |key, entry|
+              candidates << [key, entry.expires_at] if entry&.expires_at
+            end
             candidates.sort_by! { |_, exp| exp }
 
             target_size = (max * 0.9).to_i

--- a/app/web/request/rate_limiter.rb
+++ b/app/web/request/rate_limiter.rb
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require 'concurrent/map'
+require 'rack/request'
+require 'rack/response'
+
+module Html2rss
+  module Web
+    ##
+    # Rack middleware providing IP-based rate limiting with thread-safe tracking,
+    # automated pruning, and standardized 429 error formatting.
+    class RateLimiter
+      ##
+      # Encapsulates timestamp tracking and rate limit logic for a single client IP.
+      class RequestTrack
+        def initialize
+          @mutex = Mutex.new
+          @timestamps = []
+        end
+
+        # Records request time, prunes old timestamps, and checks if limit is exceeded.
+        #
+        # @param now [Integer]
+        # @param window_seconds [Integer]
+        # @param max_requests [Integer]
+        # @return [Array<(Boolean, Integer, nil)>] limit exceeded flag and retry_after seconds.
+        # rubocop:disable Metrics/MethodLength
+        def record_and_check_limit(now, window_seconds, max_requests)
+          @mutex.synchronize do
+            window_start = now - window_seconds
+            @timestamps.reject! { |t| t < window_start }
+
+            if @timestamps.size >= max_requests
+              oldest = @timestamps.min
+              retry_after = [1, oldest + window_seconds - now].max
+              [true, retry_after]
+            else
+              @timestamps << now
+              [false, nil]
+            end
+          end
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        # Prunes expired timestamps and checks if the track is empty.
+        #
+        # @param window_start [Integer]
+        # @return [Boolean] true if no timestamps remain.
+        def prune(window_start)
+          @mutex.synchronize do
+            @timestamps.reject! { |t| t < window_start }
+            @timestamps.empty?
+          end
+        end
+      end
+
+      # @param app [#call]
+      def initialize(app)
+        @app = app
+        @history = Concurrent::Map.new
+      end
+
+      # @param env [Hash]
+      # @return [Array<(Integer, Hash, #each)>]
+      # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+      def call(env)
+        return @app.call(env) unless Flags.rate_limit_enabled?
+
+        request = Rack::Request.new(env)
+        path = request.path_info.to_s
+        return @app.call(env) if bypass?(path)
+
+        prune_history_if_needed
+
+        client_key = request.ip
+        now = Time.now.to_i
+        track = @history.compute_if_absent(client_key) { RequestTrack.new }
+
+        limit_exceeded, retry_after = track.record_and_check_limit(
+          now,
+          Flags.rate_limit_window_seconds,
+          Flags.rate_limit_max_requests
+        )
+
+        if limit_exceeded
+          error = TooManyRequestsError.new
+          response = Rack::Response.new
+          response.status = 429
+          response['Retry-After'] = retry_after.to_s
+
+          body = ErrorResponder.respond(request: request, response: response, error: error)
+          response.write(body)
+          return response.finish
+        end
+
+        @app.call(env)
+      end
+      # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
+
+      private
+
+      # Bypasses rate limiting for root, static assets, and health checks.
+      #
+      # @param path [String]
+      # @return [Boolean]
+      def bypass?(path)
+        path == '/' ||
+          path.start_with?('/assets/') ||
+          path == '/api/v1/health' ||
+          path.start_with?('/api/v1/health/')
+      end
+
+      # Prunes inactive IP tracks on 1% of requests or when history grows too large.
+      #
+      # @return [void]
+      # rubocop:disable Metrics/MethodLength
+      def prune_history_if_needed
+        return unless @history.size > 1000 || Random.rand(100).zero?
+
+        now = Time.now.to_i
+        window_start = now - Flags.rate_limit_window_seconds
+
+        @history.each_key do |key|
+          track = @history[key]
+          if track
+            is_empty = track.prune(window_start)
+            @history.delete(key) if is_empty
+          end
+        end
+        nil
+      end
+      # rubocop:enable Metrics/MethodLength
+    end
+  end
+end

--- a/app/web/request/rate_limiter.rb
+++ b/app/web/request/rate_limiter.rb
@@ -40,7 +40,7 @@ module Html2rss
               [true, retry_after, false]
             else
               @timestamps << now
-              [false, nil, false]
+              [false, 0, false]
             end
           end
         end
@@ -123,6 +123,11 @@ module Html2rss
 
         if limit_exceeded
           SecurityLogger.log_rate_limit_exceeded(client_key, path, Flags.rate_limit_max_requests)
+
+          # Ensure feed endpoints get feed-formatted errors
+          if path.start_with?('/api/v1/feeds/') || !path.start_with?('/api/v1/')
+            env[RequestTarget::ENV_KEY] = RequestTarget::FEED
+          end
 
           error = TooManyRequestsError.new
           response = Rack::Response.new

--- a/app/web/request/rate_limiter.rb
+++ b/app/web/request/rate_limiter.rb
@@ -3,6 +3,7 @@
 require 'concurrent/map'
 require 'rack/request'
 require 'rack/response'
+require 'rack/utils'
 
 module Html2rss
   module Web
@@ -16,6 +17,14 @@ module Html2rss
         def initialize
           @mutex = Mutex.new
           @timestamps = []
+          @deleted = false
+        end
+
+        # Checks if this track has been deleted/pruned.
+        #
+        # @return [Boolean]
+        def deleted?
+          @mutex.synchronize { @deleted }
         end
 
         # Records request time, prunes old timestamps, and checks if limit is exceeded.
@@ -23,20 +32,22 @@ module Html2rss
         # @param now [Integer]
         # @param window_seconds [Integer]
         # @param max_requests [Integer]
-        # @return [Array<(Boolean, Integer, nil)>] limit exceeded flag and retry_after seconds.
+        # @return [Array<(Boolean, Integer, Boolean)>] limit exceeded flag, retry_after seconds, and deleted flag.
         # rubocop:disable Metrics/MethodLength
         def record_and_check_limit(now, window_seconds, max_requests)
           @mutex.synchronize do
+            return [false, 0, true] if @deleted
+
             window_start = now - window_seconds
             @timestamps.reject! { |t| t < window_start }
 
             if @timestamps.size >= max_requests
               oldest = @timestamps.first
               retry_after = [1, oldest + window_seconds - now].max
-              [true, retry_after]
+              [true, retry_after, false]
             else
               @timestamps << now
-              [false, nil]
+              [false, nil, false]
             end
           end
         end
@@ -56,8 +67,12 @@ module Html2rss
           begin
             @timestamps.reject! { |t| t < window_start }
             if @timestamps.empty?
-              history.delete(key)
-              true
+              if history.delete_pair(key, self)
+                @deleted = true
+                true
+              else
+                false
+              end
             else
               false
             end
@@ -83,20 +98,35 @@ module Html2rss
         return @app.call(env) unless Flags.rate_limit_enabled?
 
         request = Rack::Request.new(env)
-        path = request.path_info.to_s
+        path = Rack::Utils.clean_path_info(request.path_info.to_s)
         return @app.call(env) if bypass?(path)
 
         prune_history_if_needed
 
         client_key = request.ip
         now = Time.now.to_i
-        track = @history.compute_if_absent(client_key) { RequestTrack.new }
 
-        limit_exceeded, retry_after = track.record_and_check_limit(
-          now,
-          Flags.rate_limit_window_seconds,
-          Flags.rate_limit_max_requests
-        )
+        limit_exceeded = false
+        retry_after = nil
+
+        loop do
+          track = @history.compute_if_absent(client_key) { RequestTrack.new }
+
+          exceeded, after, deleted = track.record_and_check_limit(
+            now,
+            Flags.rate_limit_window_seconds,
+            Flags.rate_limit_max_requests
+          )
+
+          if deleted
+            @history.delete_pair(client_key, track)
+            next
+          end
+
+          limit_exceeded = exceeded
+          retry_after = after
+          break
+        end
 
         if limit_exceeded
           SecurityLogger.log_rate_limit_exceeded(client_key, path, Flags.rate_limit_max_requests)
@@ -133,47 +163,61 @@ module Html2rss
       # Hard-caps the history size to prevent OOM.
       #
       # @return [void]
+      # rubocop:disable Metrics/MethodLength
       def prune_history_if_needed
         now = Time.now.to_i
         size = @history.size
 
         if size > 20_000
-          handle_overflow(size, now)
+          @prune_mutex.synchronize do
+            handle_overflow(now) if @history.size > 20_000
+          end
         elsif size > 1000 && (now - @last_pruned) > 10 && @prune_mutex.try_lock
-          perform_cleanup(now)
+          begin
+            @last_pruned = now
+            prune_all_expired(now)
+          ensure
+            @prune_mutex.unlock
+          end
         end
         nil
       end
+      # rubocop:enable Metrics/MethodLength
 
-      # Handles history map overflow by logging a security event and clearing.
+      # Handles history map overflow by logging a security event and evicting entries.
       #
-      # @param size [Integer]
       # @param now [Integer]
       # @return [void]
-      def handle_overflow(size, now)
+      # rubocop:disable Metrics/MethodLength
+      def handle_overflow(now)
+        @last_pruned = now
+        prune_all_expired(now)
+
+        post_prune_size = @history.size
+        return if post_prune_size <= 20_000
+
         SecurityLogger.log_suspicious_activity(
           'system',
           'rate_limiter_history_overflow',
-          { size: size, action: 'clear_history' }
+          { size: post_prune_size, action: 'prune_to_limit' }
         )
-        @history.clear
-        @last_pruned = now
+
+        keys_to_evict = @history.keys.sample(post_prune_size - 10_000)
+        keys_to_evict.each { |k| @history.delete(k) }
       end
+      # rubocop:enable Metrics/MethodLength
 
       # Iterates over history and prunes inactive tracks.
       #
       # @param now [Integer]
       # @return [void]
-      def perform_cleanup(now)
-        @last_pruned = now
+      def prune_all_expired(now)
         window_start = now - Flags.rate_limit_window_seconds
 
         @history.each_key do |key|
           track = @history[key]
           track&.prune(window_start, @history, key)
         end
-      ensure
-        @prune_mutex.unlock
       end
     end
   end

--- a/app/web/request/rate_limiter.rb
+++ b/app/web/request/rate_limiter.rb
@@ -31,7 +31,7 @@ module Html2rss
             @timestamps.reject! { |t| t < window_start }
 
             if @timestamps.size >= max_requests
-              oldest = @timestamps.min
+              oldest = @timestamps.first
               retry_after = [1, oldest + window_seconds - now].max
               [true, retry_after]
             else
@@ -42,22 +42,38 @@ module Html2rss
         end
         # rubocop:enable Metrics/MethodLength
 
-        # Prunes expired timestamps and checks if the track is empty.
+        # Prunes expired timestamps and deletes the key from history if empty.
+        # Uses non-blocking try_lock to avoid blocking the pruning thread.
         #
         # @param window_start [Integer]
-        # @return [Boolean] true if no timestamps remain.
-        def prune(window_start)
-          @mutex.synchronize do
+        # @param history [Concurrent::Map]
+        # @param key [String]
+        # @return [Boolean] true if key was pruned and deleted.
+        # rubocop:disable Metrics/MethodLength
+        def prune(window_start, history, key)
+          return false unless @mutex.try_lock
+
+          begin
             @timestamps.reject! { |t| t < window_start }
-            @timestamps.empty?
+            if @timestamps.empty?
+              history.delete(key)
+              true
+            else
+              false
+            end
+          ensure
+            @mutex.unlock
           end
         end
+        # rubocop:enable Metrics/MethodLength
       end
 
       # @param app [#call]
       def initialize(app)
         @app = app
         @history = Concurrent::Map.new
+        @last_pruned = 0
+        @prune_mutex = Mutex.new
       end
 
       # @param env [Hash]
@@ -83,6 +99,8 @@ module Html2rss
         )
 
         if limit_exceeded
+          SecurityLogger.log_rate_limit_exceeded(client_key, path, Flags.rate_limit_max_requests)
+
           error = TooManyRequestsError.new
           response = Rack::Response.new
           response.status = 429
@@ -110,26 +128,53 @@ module Html2rss
           path.start_with?('/api/v1/health/')
       end
 
-      # Prunes inactive IP tracks on 1% of requests or when history grows too large.
+      # Prunes inactive IP tracks when history grows too large.
+      # Utilizes a prune mutex and a time-based throttle to minimize CPU overhead.
+      # Hard-caps the history size to prevent OOM.
       #
       # @return [void]
-      # rubocop:disable Metrics/MethodLength
       def prune_history_if_needed
-        return unless @history.size > 1000 || Random.rand(100).zero?
-
         now = Time.now.to_i
+        size = @history.size
+
+        if size > 20_000
+          handle_overflow(size, now)
+        elsif size > 1000 && (now - @last_pruned) > 10 && @prune_mutex.try_lock
+          perform_cleanup(now)
+        end
+        nil
+      end
+
+      # Handles history map overflow by logging a security event and clearing.
+      #
+      # @param size [Integer]
+      # @param now [Integer]
+      # @return [void]
+      def handle_overflow(size, now)
+        SecurityLogger.log_suspicious_activity(
+          'system',
+          'rate_limiter_history_overflow',
+          { size: size, action: 'clear_history' }
+        )
+        @history.clear
+        @last_pruned = now
+      end
+
+      # Iterates over history and prunes inactive tracks.
+      #
+      # @param now [Integer]
+      # @return [void]
+      def perform_cleanup(now)
+        @last_pruned = now
         window_start = now - Flags.rate_limit_window_seconds
 
         @history.each_key do |key|
           track = @history[key]
-          if track
-            is_empty = track.prune(window_start)
-            @history.delete(key) if is_empty
-          end
+          track&.prune(window_start, @history, key)
         end
-        nil
+      ensure
+        @prune_mutex.unlock
       end
-      # rubocop:enable Metrics/MethodLength
     end
   end
 end

--- a/app/web/request/rate_limiter.rb
+++ b/app/web/request/rate_limiter.rb
@@ -20,13 +20,6 @@ module Html2rss
           @deleted = false
         end
 
-        # Checks if this track has been deleted/pruned.
-        #
-        # @return [Boolean]
-        def deleted?
-          @mutex.synchronize { @deleted }
-        end
-
         # Records request time, prunes old timestamps, and checks if limit is exceeded.
         #
         # @param now [Integer]

--- a/frontend/src/api/generated/types.gen.ts
+++ b/frontend/src/api/generated/types.gen.ts
@@ -81,6 +81,20 @@ export type CreateFeedErrors = {
         };
         success: boolean;
     };
+    /**
+     * returns 429 when rate limit is exceeded
+     */
+    429: {
+        error: {
+            code: string;
+            kind: string;
+            message: string;
+            next_action: string;
+            retry_action: string;
+            retryable: boolean;
+        };
+        success: boolean;
+    };
 };
 
 export type CreateFeedError = CreateFeedErrors[keyof CreateFeedErrors];
@@ -130,9 +144,21 @@ export type RenderFeedByTokenErrors = {
      */
     403: string;
     /**
+     * returns 429 when rate limit is exceeded
+     */
+    429: string;
+    /**
      * returns non-cacheable feed errors when service generation fails
      */
     500: string;
+    /**
+     * returns 503 when the server times out
+     */
+    503: string;
+    /**
+     * returns 504 when the gateway times out
+     */
+    504: string;
 };
 
 export type RenderFeedByTokenError = RenderFeedByTokenErrors[keyof RenderFeedByTokenErrors];

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -83,8 +83,9 @@ paths:
                 - success
                 - data
                 type: object
-          description: returns API information with trailing slash
-      security: []
+          description: returns OpenAPI document URL in metadata
+      security:
+      - {}
       summary: API metadata
       tags:
       - Root
@@ -265,6 +266,11 @@ paths:
                 - error
                 type: object
           description: returns 429 when rate limit is exceeded
+          headers:
+            Retry-After:
+              description: The number of seconds to wait before retrying the request.
+              schema:
+                type: integer
       security:
       - BearerAuth: []
       summary: Create a feed
@@ -322,37 +328,6 @@ paths:
               example: '{"version":"https://jsonfeed.org/version/1.1","title":"Error"}'
               schema:
                 type: string
-            application/json:
-              schema:
-                properties:
-                  error:
-                    properties:
-                      code:
-                        type: string
-                      kind:
-                        type: string
-                      message:
-                        type: string
-                      next_action:
-                        type: string
-                      retry_action:
-                        type: string
-                      retryable:
-                        type: boolean
-                    required:
-                    - message
-                    - code
-                    - retryable
-                    - next_action
-                    - retry_action
-                    - kind
-                    type: object
-                  success:
-                    type: boolean
-                required:
-                - success
-                - error
-                type: object
             application/xml:
               example: |-
                 <?xml version="1.0" encoding="UTF-8"?>
@@ -360,6 +335,11 @@ paths:
               schema:
                 type: string
           description: returns 429 when rate limit is exceeded
+          headers:
+            Retry-After:
+              description: The number of seconds to wait before retrying the request.
+              schema:
+                type: integer
         '500':
           content:
             application/feed+json:
@@ -386,6 +366,11 @@ paths:
               schema:
                 type: string
           description: returns 503 when the server times out
+          headers:
+            Retry-After:
+              description: The number of seconds to wait before retrying the request.
+              schema:
+                type: integer
         '504':
           content:
             application/feed+json:
@@ -399,7 +384,13 @@ paths:
               schema:
                 type: string
           description: returns 504 when the gateway times out
-      security: []
+          headers:
+            Retry-After:
+              description: The number of seconds to wait before retrying the request.
+              schema:
+                type: integer
+      security:
+      - {}
       summary: Render feed by token
       tags:
       - Feeds
@@ -557,7 +548,8 @@ paths:
                 - data
                 type: object
           description: returns liveness status without authentication
-      security: []
+      security:
+      - {}
       summary: Liveness probe
       tags:
       - Health
@@ -604,7 +596,8 @@ paths:
                 - data
                 type: object
           description: returns readiness status without authentication
-      security: []
+      security:
+      - {}
       summary: Readiness probe
       tags:
       - Health
@@ -653,7 +646,8 @@ paths:
                 - meta
                 type: object
           description: returns available strategies
-      security: []
+      security:
+      - {}
       summary: List extraction strategies
       tags:
       - Strategies

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -231,6 +231,40 @@ paths:
                 type: object
           description: returns forbidden for authenticated requests when auto source
             is disabled
+        '429':
+          content:
+            application/json:
+              schema:
+                properties:
+                  error:
+                    properties:
+                      code:
+                        type: string
+                      kind:
+                        type: string
+                      message:
+                        type: string
+                      next_action:
+                        type: string
+                      retry_action:
+                        type: string
+                      retryable:
+                        type: boolean
+                    required:
+                    - message
+                    - code
+                    - retryable
+                    - next_action
+                    - retry_action
+                    - kind
+                    type: object
+                  success:
+                    type: boolean
+                required:
+                - success
+                - error
+                type: object
+          description: returns 429 when rate limit is exceeded
       security:
       - BearerAuth: []
       summary: Create a feed
@@ -282,6 +316,50 @@ paths:
               schema:
                 type: string
           description: returns forbidden when auto source is disabled
+        '429':
+          content:
+            application/feed+json:
+              example: '{"version":"https://jsonfeed.org/version/1.1","title":"Error"}'
+              schema:
+                type: string
+            application/json:
+              schema:
+                properties:
+                  error:
+                    properties:
+                      code:
+                        type: string
+                      kind:
+                        type: string
+                      message:
+                        type: string
+                      next_action:
+                        type: string
+                      retry_action:
+                        type: string
+                      retryable:
+                        type: boolean
+                    required:
+                    - message
+                    - code
+                    - retryable
+                    - next_action
+                    - retry_action
+                    - kind
+                    type: object
+                  success:
+                    type: boolean
+                required:
+                - success
+                - error
+                type: object
+            application/xml:
+              example: |-
+                <?xml version="1.0" encoding="UTF-8"?>
+                <rss version="2.0"><channel><title>Error</title><description>Internal Server Error</description></channel></rss>
+              schema:
+                type: string
+          description: returns 429 when rate limit is exceeded
         '500':
           content:
             application/feed+json:
@@ -295,6 +373,32 @@ paths:
               schema:
                 type: string
           description: returns non-cacheable feed errors when service generation fails
+        '503':
+          content:
+            application/feed+json:
+              example: '{"version":"https://jsonfeed.org/version/1.1","title":"Error"}'
+              schema:
+                type: string
+            application/xml:
+              example: |-
+                <?xml version="1.0" encoding="UTF-8"?>
+                <rss version="2.0"><channel><title>Error</title><description>Internal Server Error</description></channel></rss>
+              schema:
+                type: string
+          description: returns 503 when the server times out
+        '504':
+          content:
+            application/feed+json:
+              example: '{"version":"https://jsonfeed.org/version/1.1","title":"Error"}'
+              schema:
+                type: string
+            application/xml:
+              example: |-
+                <?xml version="1.0" encoding="UTF-8"?>
+                <rss version="2.0"><channel><title>Error</title><description>Internal Server Error</description></channel></rss>
+              schema:
+                type: string
+          description: returns 504 when the gateway times out
       security: []
       summary: Render feed by token
       tags:

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -83,7 +83,7 @@ paths:
                 - success
                 - data
                 type: object
-          description: returns OpenAPI document URL in metadata
+          description: returns API information with trailing slash
       security:
       - {}
       summary: API metadata

--- a/spec/html2rss/web/api/v1_spec.rb
+++ b/spec/html2rss/web/api/v1_spec.rb
@@ -515,6 +515,51 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
       expect(last_response.headers['Cache-Control']).to include('max-age=600')
       expect(JSON.parse(last_response.body).fetch('title')).to eq('Content Extraction Issue')
     end
+
+    # rubocop:disable RSpec/ExampleLength
+    it 'returns 429 when rate limit is exceeded', :aggregate_failures do
+      allow(Html2rss::Web::Flags).to receive_messages(
+        rate_limit_enabled?: true,
+        rate_limit_max_requests: 1,
+        rate_limit_window_seconds: 60
+      )
+
+      token = Html2rss::Web::Auth.generate_feed_token('admin', "#{feed_url}/rate-limited-429", strategy: 'faraday')
+      allow(Html2rss::Web::Feeds::Service).to receive(:call).and_return(feed_result)
+      allow(Html2rss::Web::Feeds::RssRenderer).to receive(:call).and_return('<rss version="2.0"></rss>')
+
+      get "/api/v1/feeds/#{token}.xml", {}, { 'REMOTE_ADDR' => '192.168.99.1' }
+      expect(last_response.status).to eq(200)
+
+      get "/api/v1/feeds/#{token}.xml", {}, { 'REMOTE_ADDR' => '192.168.99.1' }
+      expect(last_response.status).to eq(429)
+      expect(last_response.headers['Retry-After']).not_to be_nil
+    end
+    # rubocop:enable RSpec/ExampleLength
+
+    it 'returns 503 when the server times out', :aggregate_failures do
+      token = Html2rss::Web::Auth.generate_feed_token('admin', "#{feed_url}/timeout-503", strategy: 'faraday')
+      stub_const('Rack::Timeout::RequestTimeoutException', Class.new(StandardError))
+
+      allow(Html2rss::Web::Feeds::Service).to receive(:call)
+        .and_raise(Rack::Timeout::RequestTimeoutException.new('service timeout'))
+
+      get "/api/v1/feeds/#{token}.xml"
+
+      expect(last_response.status).to eq(503)
+      expect(last_response.headers['Retry-After']).not_to be_nil
+    end
+
+    it 'returns 504 when the gateway times out', :aggregate_failures do
+      token = Html2rss::Web::Auth.generate_feed_token('admin', "#{feed_url}/timeout-504", strategy: 'faraday')
+
+      allow(Html2rss::Web::Feeds::Service).to receive(:call).and_raise(Timeout::Error.new('gateway timeout'))
+
+      get "/api/v1/feeds/#{token}.xml"
+
+      expect(last_response.status).to eq(504)
+      expect(last_response.headers['Retry-After']).not_to be_nil
+    end
   end
 
   describe 'POST /api/v1/feeds', openapi: {
@@ -587,6 +632,23 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
         retry_action: 'none'
       )
       expect(json.dig('error', 'message')).to eq(Html2rss::Web::AutoSourceDisabledError::DEFAULT_MESSAGE)
+    end
+
+    it 'returns 429 when rate limit is exceeded', :aggregate_failures do
+      allow(Html2rss::Web::Flags).to receive_messages(
+        rate_limit_enabled?: true,
+        rate_limit_max_requests: 1,
+        rate_limit_window_seconds: 60
+      )
+
+      header 'Authorization', "Bearer #{admin_token}"
+      header 'Content-Type', 'application/json'
+      post '/api/v1/feeds', { url: 'https://example.com/articles-post-429' }.to_json, { 'REMOTE_ADDR' => '192.168.99.2' }
+      expect(last_response.status).to eq(201)
+
+      post '/api/v1/feeds', { url: 'https://example.com/articles-post-429' }.to_json, { 'REMOTE_ADDR' => '192.168.99.2' }
+      expect(last_response.status).to eq(429)
+      expect(last_response.headers['Retry-After']).not_to be_nil
     end
   end
 end

--- a/spec/html2rss/web/api/v1_spec.rb
+++ b/spec/html2rss/web/api/v1_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
     header 'Accept', nil
   end
 
-  let(:health_token) { 'CHANGE_ME_HEALTH_CHECK_TOKEN' }
+  let(:health_token) { Html2rss::Web::RuntimeEnv.health_check_token }
   let(:admin_token) { 'CHANGE_ME_ADMIN_TOKEN' }
   let(:feed_url) { 'https://example.com/articles' }
 
@@ -153,7 +153,7 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
     summary: 'API metadata',
     operation_id: 'getApiMetadata',
     tags: ['Root'],
-    security: []
+    security: [{}]
   } do
     it 'returns API information', :aggregate_failures do
       get '/api/v1'
@@ -308,7 +308,7 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
     summary: 'Readiness probe',
     operation_id: 'getReadinessProbe',
     tags: ['Health'],
-    security: []
+    security: [{}]
   } do
     it 'returns readiness status without authentication', :aggregate_failures do
       get '/api/v1/health/ready'
@@ -324,7 +324,7 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
     summary: 'Liveness probe',
     operation_id: 'getLivenessProbe',
     tags: ['Health'],
-    security: []
+    security: [{}]
   } do
     it 'returns liveness status without authentication', :aggregate_failures do
       get '/api/v1/health/live'
@@ -340,7 +340,7 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
     summary: 'List extraction strategies',
     operation_id: 'listStrategies',
     tags: ['Strategies'],
-    security: []
+    security: [{}]
   } do
     it 'returns available strategies', :aggregate_failures do
       get '/api/v1/strategies'
@@ -356,7 +356,7 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
     summary: 'Render feed by token',
     operation_id: 'renderFeedByToken',
     tags: ['Feeds'],
-    security: [],
+    security: [{}],
     example_mode: :multiple
   } do
     before do

--- a/spec/html2rss/web/error_responder_spec.rb
+++ b/spec/html2rss/web/error_responder_spec.rb
@@ -119,6 +119,37 @@ RSpec.describe Html2rss::Web::ErrorResponder do
     it 'keeps the xml error representation when xml outranks json' do
       expect(xml_preferred_feed_error_response).to eq(['application/xml', true])
     end
+
+    it 'maps TooManyRequestsError to 429 and injects Retry-After header', :aggregate_failures do
+      response, _body = respond_with(
+        error: Html2rss::Web::TooManyRequestsError.new,
+        path: '/api/v1/feeds',
+        target: Html2rss::Web::RequestTarget::API
+      )
+      expect(response.status).to eq(429)
+      expect(response['Retry-After']).to eq('60')
+    end
+
+    it 'maps Rack::Timeout::RequestTimeoutException to 503 and injects Retry-After header', :aggregate_failures do
+      stub_const('Rack::Timeout::RequestTimeoutException', Class.new(StandardError))
+      response, _body = respond_with(
+        error: Rack::Timeout::RequestTimeoutException.new('timeout'),
+        path: '/api/v1/feeds',
+        target: Html2rss::Web::RequestTarget::API
+      )
+      expect(response.status).to eq(503)
+      expect(response['Retry-After']).to eq('300')
+    end
+
+    it 'maps network timeouts to 504 and injects Retry-After header', :aggregate_failures do
+      response, _body = respond_with(
+        error: Net::OpenTimeout.new('timeout'),
+        path: '/api/v1/feeds',
+        target: Html2rss::Web::RequestTarget::API
+      )
+      expect(response.status).to eq(504)
+      expect(response['Retry-After']).to eq('300')
+    end
   end
 
   # @return [Hash{String=>Object}]

--- a/spec/html2rss/web/feeds/cache_eviction_spec.rb
+++ b/spec/html2rss/web/feeds/cache_eviction_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../../app'
+
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe 'Cache Eviction' do
+  let(:cache) { Html2rss::Web::Feeds::Cache }
+
+  before do
+    cache.clear!
+  end
+
+  def build_result(title)
+    Html2rss::Web::Feeds::Contracts::RenderResult.new(
+      status: :ok,
+      payload: Html2rss::Web::Feeds::Contracts::RenderPayload.new(
+        feed: Object.new, site_title: title, url: 'https://example.com', strategy: 'faraday'
+      ),
+      message: nil, ttl_seconds: 60, cache_key: "feed_result:#{title}", error_message: nil, error_kind: nil
+    )
+  end
+
+  it 'respects the max size and evicts expiring soonest when exceeded', :aggregate_failures do
+    allow(Html2rss::Web::Flags).to receive(:feeds_cache_max_size).and_return(3)
+
+    cache.fetch('key1', ttl_seconds: 10) { build_result('one') }
+    cache.fetch('key2', ttl_seconds: 20) { build_result('two') }
+    cache.fetch('key3', ttl_seconds: 30) { build_result('three') }
+
+    # Writing 4th entry triggers eviction. Target size: 2.
+    cache.fetch('key4', ttl_seconds: 40) { build_result('four') }
+
+    allow(Html2rss::Web::Flags).to receive(:feeds_cache_max_size).and_return(10)
+
+    # Verify key1 is evicted (yields on next fetch)
+    yielded_key1 = false
+    cache.fetch('key1', ttl_seconds: 10) { yielded_key1 = true; build_result('one') } # rubocop:disable Style/Semicolon
+    expect(yielded_key1).to be(true)
+
+    # Verify key2, key3, and key4 are still cached
+    yielded_key2 = false
+    cache.fetch('key2', ttl_seconds: 20) { yielded_key2 = true; build_result('two') } # rubocop:disable Style/Semicolon
+    expect(yielded_key2).to be(false)
+
+    yielded_key3 = false
+    cache.fetch('key3', ttl_seconds: 30) { yielded_key3 = true; build_result('three') } # rubocop:disable Style/Semicolon
+    expect(yielded_key3).to be(false)
+
+    yielded_key4 = false
+    cache.fetch('key4', ttl_seconds: 40) { yielded_key4 = true; build_result('four') } # rubocop:disable Style/Semicolon
+    expect(yielded_key4).to be(false)
+  end
+
+  it 'prunes expired entries first', :aggregate_failures do
+    allow(Html2rss::Web::Flags).to receive(:feeds_cache_max_size).and_return(3)
+
+    base_time = Time.now.utc
+    allow(Time).to receive(:now).and_return(base_time)
+
+    cache.fetch('key1', ttl_seconds: 10) { build_result('one') }
+    cache.fetch('key2', ttl_seconds: 20) { build_result('two') }
+    cache.fetch('key3', ttl_seconds: 30) { build_result('three') }
+
+    allow(Time).to receive(:now).and_return(base_time + 15)
+
+    # Write 4th entry. First pass deletes 'key1' (expired). Size is 2 (< 3), no other evictions.
+    cache.fetch('key4', ttl_seconds: 40) { build_result('four') }
+
+    allow(Html2rss::Web::Flags).to receive(:feeds_cache_max_size).and_return(10)
+
+    # Verify key1 yields (expired/evicted)
+    yielded_key1 = false
+    cache.fetch('key1', ttl_seconds: 10) { yielded_key1 = true; build_result('one') } # rubocop:disable Style/Semicolon
+    expect(yielded_key1).to be(true)
+
+    # Verify key2 and key3 are still cached
+    yielded_key2 = false
+    cache.fetch('key2', ttl_seconds: 20) { yielded_key2 = true; build_result('two') } # rubocop:disable Style/Semicolon
+    expect(yielded_key2).to be(false)
+
+    yielded_key3 = false
+    cache.fetch('key3', ttl_seconds: 30) { yielded_key3 = true; build_result('three') } # rubocop:disable Style/Semicolon
+    expect(yielded_key3).to be(false)
+  end
+end
+# rubocop:enable RSpec/ExampleLength

--- a/spec/html2rss/web/flags_spec.rb
+++ b/spec/html2rss/web/flags_spec.rb
@@ -20,6 +20,20 @@ RSpec.describe Html2rss::Web::Flags do
     end
   end
 
+  describe '.feeds_cache_max_size' do
+    it 'defaults to 500 when unset' do
+      ClimateControl.modify('FEEDS_CACHE_MAX_SIZE' => nil) do
+        expect(described_class.feeds_cache_max_size).to eq(500)
+      end
+    end
+
+    it 'returns the configured integer' do
+      ClimateControl.modify('FEEDS_CACHE_MAX_SIZE' => '100') do
+        expect(described_class.feeds_cache_max_size).to eq(100)
+      end
+    end
+  end
+
   describe '.validate!' do
     it 'raises for malformed boolean values' do
       ClimateControl.modify('AUTO_SOURCE_ENABLED' => 'not-a-bool') do
@@ -35,6 +49,12 @@ RSpec.describe Html2rss::Web::Flags do
 
     it 'raises for malformed stale factor' do
       ClimateControl.modify('ASYNC_FEED_REFRESH_STALE_FACTOR' => '0') do
+        expect { described_class.validate! }.to raise_error(ArgumentError, /failed constraints/)
+      end
+    end
+
+    it 'raises for invalid feeds cache max size' do
+      ClimateControl.modify('FEEDS_CACHE_MAX_SIZE' => '0') do
         expect { described_class.validate! }.to raise_error(ArgumentError, /failed constraints/)
       end
     end

--- a/spec/html2rss/web/rate_limiter_spec.rb
+++ b/spec/html2rss/web/rate_limiter_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rack/mock'
+require 'climate_control'
+require_relative '../../../app'
+
+RSpec.describe Html2rss::Web::RateLimiter do
+  let(:inner_app) { ->(_env) { [200, { 'Content-Type' => 'text/plain' }, ['ok']] } }
+  let(:middleware) { described_class.new(inner_app) }
+  let(:request_builder) { Rack::MockRequest.new(middleware) }
+
+  before do
+    allow(Html2rss::Web::Flags).to receive_messages(
+      rate_limit_enabled?: true,
+      rate_limit_max_requests: 3,
+      rate_limit_window_seconds: 10
+    )
+  end
+
+  it 'allows requests under the limit' do
+    3.times do
+      response = request_builder.get('/api/v1/feeds')
+      expect(response.status).to eq(200)
+      expect(response.body).to eq('ok')
+    end
+  end
+
+  it 'returns 429 and Retry-After header when limit is exceeded', :aggregate_failures do
+    3.times { request_builder.get('/api/v1/feeds') }
+
+    response = request_builder.get('/api/v1/feeds')
+    expect(response.status).to eq(429)
+    expect(response['Retry-After']).to eq('10')
+    expect(response['Content-Type']).to eq('application/json')
+
+    body = JSON.parse(response.body)
+    expect(body['success']).to be(false)
+    expect(body.dig('error', 'code')).to eq('TOO_MANY_REQUESTS')
+  end
+
+  it 'bypasses rate limiting for health check routes' do
+    4.times do
+      response = request_builder.get('/api/v1/health')
+      expect(response.status).to eq(200)
+    end
+  end
+
+  it 'bypasses rate limiting for static assets' do
+    4.times do
+      response = request_builder.get('/assets/logo.png')
+      expect(response.status).to eq(200)
+    end
+  end
+
+  it 'bypasses rate limiting for root path' do
+    4.times do
+      response = request_builder.get('/')
+      expect(response.status).to eq(200)
+    end
+  end
+
+  it 'can be disabled via Flags' do
+    allow(Html2rss::Web::Flags).to receive(:rate_limit_enabled?).and_return(false)
+    4.times do
+      response = request_builder.get('/api/v1/feeds')
+      expect(response.status).to eq(200)
+    end
+  end
+
+  it 'prunes history when map size exceeds limit' do
+    history_map = middleware.instance_variable_get(:@history)
+    1005.times do |i|
+      history_map["192.168.1.#{i}"] = described_class::RequestTrack.new
+    end
+
+    expect(history_map.size).to eq(1005)
+
+    request_builder.get('/api/v1/feeds')
+
+    expect(history_map.size).to eq(1)
+  end
+end

--- a/spec/html2rss/web/rate_limiter_spec.rb
+++ b/spec/html2rss/web/rate_limiter_spec.rb
@@ -81,20 +81,34 @@ RSpec.describe Html2rss::Web::RateLimiter do
     expect(history_map.size).to eq(1)
   end
 
+  it 'does not bypass rate limiting for path traversal attempts' do
+    3.times { request_builder.get('/assets/../api/v1/feeds') }
+    response = request_builder.get('/assets/../api/v1/feeds')
+    expect(response.status).to eq(429)
+  end
+
   context 'when under memory pressure or rate limit breaches' do
-    it 'clears history on overflow to prevent OOM', :aggregate_failures do
+    # rubocop:disable RSpec/ExampleLength
+    it 'prunes to limit on overflow to prevent OOM', :aggregate_failures do
       history_map = middleware.instance_variable_get(:@history)
-      20_005.times { |i| history_map["192.168.1.#{i}"] = described_class::RequestTrack.new }
+      now = Time.now.to_i
+      20_005.times do |i|
+        track = described_class::RequestTrack.new
+        track.instance_variable_set(:@timestamps, [now])
+        history_map["192.168.1.#{i}"] = track
+      end
       expect(history_map.size).to eq(20_005)
 
       allow(Html2rss::Web::SecurityLogger).to receive(:log_suspicious_activity)
       request_builder.get('/api/v1/feeds')
 
       expect(Html2rss::Web::SecurityLogger).to have_received(:log_suspicious_activity).with(
-        'system', 'rate_limiter_history_overflow', hash_including(size: 20_005, action: 'clear_history')
+        'system', 'rate_limiter_history_overflow', hash_including(size: 20_005, action: 'prune_to_limit')
       )
-      expect(history_map.size).to eq(1)
+      # Should prune down to 10,000 plus the active client request track = 10,001
+      expect(history_map.size).to eq(10_001)
     end
+    # rubocop:enable RSpec/ExampleLength
 
     it 'logs rate limit exceeded events to SecurityLogger' do
       allow(Html2rss::Web::SecurityLogger).to receive(:log_rate_limit_exceeded)
@@ -123,6 +137,22 @@ RSpec.describe Html2rss::Web::RateLimiter do
 
       # Check that the locked track was NOT pruned/deleted, even though it was empty
       expect(history_map.key?('999.999.999.999')).to be(true)
+    end
+
+    it 'recovers and retries when a track is deleted during check' do
+      track = described_class::RequestTrack.new
+      track.instance_variable_set(:@deleted, true)
+
+      call_count = 0
+      original_new = described_class::RequestTrack.method(:new)
+      allow(described_class::RequestTrack).to receive(:new) do
+        call_count += 1
+        call_count == 1 ? track : original_new.call
+      end
+
+      response = request_builder.get('/api/v1/feeds')
+      expect(response.status).to eq(200)
+      expect(call_count).to eq(2)
     end
   end
 end

--- a/spec/html2rss/web/rate_limiter_spec.rb
+++ b/spec/html2rss/web/rate_limiter_spec.rb
@@ -80,4 +80,49 @@ RSpec.describe Html2rss::Web::RateLimiter do
 
     expect(history_map.size).to eq(1)
   end
+
+  context 'when under memory pressure or rate limit breaches' do
+    it 'clears history on overflow to prevent OOM', :aggregate_failures do
+      history_map = middleware.instance_variable_get(:@history)
+      20_005.times { |i| history_map["192.168.1.#{i}"] = described_class::RequestTrack.new }
+      expect(history_map.size).to eq(20_005)
+
+      allow(Html2rss::Web::SecurityLogger).to receive(:log_suspicious_activity)
+      request_builder.get('/api/v1/feeds')
+
+      expect(Html2rss::Web::SecurityLogger).to have_received(:log_suspicious_activity).with(
+        'system', 'rate_limiter_history_overflow', hash_including(size: 20_005, action: 'clear_history')
+      )
+      expect(history_map.size).to eq(1)
+    end
+
+    it 'logs rate limit exceeded events to SecurityLogger' do
+      allow(Html2rss::Web::SecurityLogger).to receive(:log_rate_limit_exceeded)
+
+      4.times { request_builder.get('/api/v1/feeds') }
+
+      expect(Html2rss::Web::SecurityLogger).to have_received(:log_rate_limit_exceeded).with(
+        anything, '/api/v1/feeds', 3
+      )
+    end
+
+    it 'skips pruning locked tracks using non-blocking try_lock' do
+      history_map = middleware.instance_variable_get(:@history)
+      track = described_class::RequestTrack.new
+      history_map['999.999.999.999'] = track
+
+      # Stub try_lock to return false, mimicking lock contention
+      allow(track.instance_variable_get(:@mutex)).to receive(:try_lock).and_return(false)
+
+      # Populate history past 1000 so pruning is triggered
+      1005.times do |i|
+        history_map["192.168.1.#{i}"] = described_class::RequestTrack.new
+      end
+
+      request_builder.get('/api/v1/feeds')
+
+      # Check that the locked track was NOT pruned/deleted, even though it was empty
+      expect(history_map.key?('999.999.999.999')).to be(true)
+    end
+  end
 end

--- a/spec/support/openapi.rb
+++ b/spec/support/openapi.rb
@@ -48,7 +48,7 @@ if ENV['OPENAPI']
 
   # Keep path keys relative to /api/v1 because servers include the versioned base path.
   RSpec::OpenAPI.post_process_hook = lambda do |_path, _records, spec|
-    token_feed_error_statuses = %w[401 403 500].freeze
+    token_feed_error_statuses = %w[401 403 429 500 503 504].freeze
 
     stringify = lambda do |value|
       case value

--- a/spec/support/openapi.rb
+++ b/spec/support/openapi.rb
@@ -174,7 +174,7 @@ if ENV['OPENAPI']
         end
 
         # Inject Retry-After header for rate limiting and timeout responses
-        %w[429 503 504].each do |status|
+        %w[429 503 504].each do |status| # rubocop:disable Performance/CollectionLiteralInLoop
           response = normalized_paths[normalized][verb].dig('responses', status)
           next unless response
 

--- a/spec/support/openapi.rb
+++ b/spec/support/openapi.rb
@@ -173,6 +173,18 @@ if ENV['OPENAPI']
           end
         end
 
+        # Inject Retry-After header for rate limiting and timeout responses
+        %w[429 503 504].each do |status|
+          response = normalized_paths[normalized][verb].dig('responses', status)
+          next unless response
+
+          response['headers'] ||= {}
+          response['headers']['Retry-After'] = {
+            'description' => 'The number of seconds to wait before retrying the request.',
+            'schema' => { 'type' => 'integer' }
+          }
+        end
+
         next unless normalized == '/feeds/{token}'
 
         token_feed_error_statuses.each do |status|


### PR DESCRIPTION
This PR implements robust client protection for html2rss-web:

- Bounded memory cache with expired-first and soonest-to-expire eviction.
- Sliding-window IP-based rate limiting middleware.
- Centralized error response status mapping (429, 503, 504) with Retry-After headers.