### PR TITLE
chore: bump version to v1.5.1

### DIFF
--- a/config/version.rb
+++ b/config/version.rb
@@ -2,7 +2,7 @@
 
 module Html2rss
   module Web
-    VERSION = '1.5.0'
+    VERSION = '1.5.1'
     public_constant :VERSION
   end
 end

--- a/public/openapi.yaml
+++ b/public/openapi.yaml
@@ -2,7 +2,7 @@
 openapi: 3.0.3
 info:
   title: html2rss-web API
-  version: 1.5.0
+  version: 1.5.1
   description: RESTful API for converting websites to RSS feeds.
   contact:
     name: html2rss-web Support


### PR DESCRIPTION
Automated version bump to `v1.5.1`.

This PR contains the version update in `config/version.rb` and regenerated OpenAPI specs and frontend API client.

### 🚀 Next Steps
1. Verify that all CI checks pass.
2. Merge this Pull Request.
3. Go to the draft release on GitHub and publish it.