### PR TITLE
refactor: deepen feed conversion, AppViewModel, ErrorClassifier, and FeedToken

### DIFF
--- a/app/web/errors/error_classifier.rb
+++ b/app/web/errors/error_classifier.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Html2rss
+  module Web
+    ##
+    # Classifies known exception chains into immutable HTTP error decisions.
+    #
+    # Ownership of +Exception#cause+ walking lives here so feed rendering and
+    # HTTP responders share one extraction-empty mapping.
+    module ErrorClassifier
+      ##
+      # Immutable HTTP decision for a classified error.
+      Decision = Data.define(:status, :code, :message, :kind, :cacheable)
+
+      EXTRACTION_EMPTY_CODE = 'EXTRACTION_EMPTY'
+      EXTRACTION_EMPTY_MESSAGE = 'We could not extract feed items from this page yet. ' \
+                                 'Try a more specific listing URL or explicit selectors.'
+
+      EXTRACTION_EMPTY = Decision.new(
+        status: 422,
+        code: EXTRACTION_EMPTY_CODE,
+        message: EXTRACTION_EMPTY_MESSAGE,
+        kind: 'input',
+        cacheable: true
+      ).freeze
+
+      class << self
+        # Returns a decision when +error+ (or a cause) is a known classified
+        # failure. Ignores gem-specific payload fields such as +attempts+.
+        #
+        # @param error [Exception]
+        # @return [Html2rss::Web::ErrorClassifier::Decision, nil]
+        def classify(error)
+          return EXTRACTION_EMPTY if extraction_empty?(error)
+
+          nil
+        end
+
+        # Walks +Exception#cause+ without following identity cycles.
+        #
+        # @param error [Exception, nil]
+        # @return [Array<Exception>]
+        def error_chain(error)
+          chain = []
+          seen = {}.compare_by_identity
+          current = error
+
+          while current && !seen[current]
+            chain << current
+            seen[current] = true
+            current = current.respond_to?(:cause) ? current.cause : nil
+          end
+
+          chain
+        end
+
+        private
+
+        # @param error [Exception]
+        # @return [Boolean]
+        def extraction_empty?(error)
+          return false unless defined?(::Html2rss::NoFeedItemsExtracted)
+
+          error_chain(error).any?(::Html2rss::NoFeedItemsExtracted)
+        end
+      end
+    end
+  end
+end

--- a/app/web/errors/error_classifier.rb
+++ b/app/web/errors/error_classifier.rb
@@ -10,7 +10,9 @@ module Html2rss
     module ErrorClassifier
       ##
       # Immutable HTTP decision for a classified error.
-      Decision = Data.define(:status, :code, :message, :kind, :cacheable)
+      Decision = Data.define(
+        :status, :code, :message, :kind, :cacheable, :retryable, :next_action, :retry_action
+      )
 
       EXTRACTION_EMPTY_CODE = 'EXTRACTION_EMPTY'
       EXTRACTION_EMPTY_MESSAGE = 'We could not extract feed items from this page yet. ' \
@@ -21,7 +23,10 @@ module Html2rss
         code: EXTRACTION_EMPTY_CODE,
         message: EXTRACTION_EMPTY_MESSAGE,
         kind: 'input',
-        cacheable: true
+        cacheable: true,
+        retryable: false,
+        next_action: 'correct_input',
+        retry_action: 'none'
       ).freeze
 
       class << self

--- a/app/web/errors/error_responder.rb
+++ b/app/web/errors/error_responder.rb
@@ -109,12 +109,23 @@ module Html2rss
         end
 
         def failure_metadata(error, decision)
-          return INPUT_META.merge(kind: decision.kind) if decision
+          return decision_metadata(decision) if decision
           return AUTH_META if error.is_a?(UnauthorizedError)
           return INPUT_META if error.is_a?(BadRequestError) || error.is_a?(ForbiddenError)
           return SERVER_META if error.is_a?(HealthCheckFailedError)
 
           RETRY_META.merge(kind: error_kind(error))
+        end
+
+        # @param decision [Html2rss::Web::ErrorClassifier::Decision]
+        # @return [Hash{Symbol=>Object}]
+        def decision_metadata(decision)
+          {
+            kind: decision.kind,
+            retryable: decision.retryable,
+            next_action: decision.next_action,
+            retry_action: decision.retry_action
+          }
         end
 
         def error_kind(error)

--- a/app/web/errors/error_responder.rb
+++ b/app/web/errors/error_responder.rb
@@ -6,9 +6,6 @@ module Html2rss
     # Centralized error rendering for API and XML endpoints.
     module ErrorResponder # rubocop:disable Metrics/ModuleLength
       API_ROOT_PATH = '/api/v1'
-      EXTRACTION_EMPTY_CODE = 'EXTRACTION_EMPTY'
-      EXTRACTION_EMPTY_MESSAGE = 'We could not extract feed items from this page yet. ' \
-                                 'Try a more specific listing URL or explicit selectors.'
       INTERNAL_ERROR_CODE = InternalServerError::CODE
       NETWORK_ERRORS = Set[
         Timeout::Error, Net::OpenTimeout, Net::ReadTimeout, SocketError,
@@ -27,8 +24,9 @@ module Html2rss
         # @return [String]
         # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
         def respond(request:, response:, error:)
-          status = resolve_status(error)
-          code = resolve_error_code(error)
+          decision = ErrorClassifier.classify(error)
+          status = resolve_status(error, decision)
+          code = resolve_error_code(error, decision)
           response.status = status
 
           if status == 429
@@ -40,49 +38,50 @@ module Html2rss
           emit_error_event(error, code, response.status)
           write_internal_error_log(request, error)
 
-          return render_feed_error(request, response, error) if request_target(request) == RequestTarget::FEED
+          return render_feed_error(request, response, error, decision) if request_target(request) == RequestTarget::FEED
           if request_target(request) == RequestTarget::API || request.path.to_s.start_with?(API_ROOT_PATH)
-            return render_api_error(request, response,
-                                    error)
+            return render_api_error(request, response, error, decision)
           end
 
-          render_xml_error(response, error)
+          render_xml_error(response, error, decision)
         end
         # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
         private
 
-        def render_feed_error(request, response, error)
+        def render_feed_error(request, response, error, decision)
           f = FeedResponseFormat.for_request(request)
           response['Content-Type'] = FeedResponseFormat.content_type(f)
-          msg = client_message_for(error)
+          msg = client_message_for(error, decision)
           return JsonFeedBuilder.build_error_feed(message: msg) if f == FeedResponseFormat::JSON_FEED
 
           XmlBuilder.build_error_feed(message: msg)
         end
 
-        def render_api_error(_request, response, error)
+        def render_api_error(_request, response, error, decision)
           response['Content-Type'] = 'application/json'
-          JSON.generate({ success: false, error: failure_payload(error) })
+          JSON.generate({ success: false, error: failure_payload(error, decision) })
         end
 
-        def render_xml_error(response, error)
+        def render_xml_error(response, error, decision)
           response['Content-Type'] = 'application/xml'
-          XmlBuilder.build_error_feed(message: client_message_for(error))
+          XmlBuilder.build_error_feed(message: client_message_for(error, decision))
         end
 
-        def resolve_error_code(error)
+        def resolve_error_code(error, decision)
+          return decision.code if decision
+
           case error
-          when ->(e) { extraction_empty_failure?(e) } then EXTRACTION_EMPTY_CODE
           when ->(e) { server_timeout?(e) } then ServiceUnavailableError::CODE
           when ->(e) { gateway_timeout?(e) } then GatewayTimeoutError::CODE
           else error.respond_to?(:code) ? error.code : INTERNAL_ERROR_CODE
           end
         end
 
-        def resolve_status(error)
+        def resolve_status(error, decision)
+          return decision.status if decision
+
           case error
-          when ->(e) { extraction_empty_failure?(e) } then 422
           when TooManyRequestsError then 429
           when ServiceUnavailableError, ->(e) { server_timeout?(e) } then 503
           when GatewayTimeoutError, ->(e) { gateway_timeout?(e) } then 504
@@ -90,9 +89,10 @@ module Html2rss
           end
         end
 
-        def client_message_for(error)
+        def client_message_for(error, decision)
+          return decision.message if decision
+
           case error
-          when ->(e) { extraction_empty_failure?(e) } then EXTRACTION_EMPTY_MESSAGE
           when TooManyRequestsError then 'Too many requests. Please wait before retrying.'
           when ServiceUnavailableError, ->(e) { server_timeout?(e) }
             'The server is too busy or the request timed out. Please try again later.'
@@ -103,24 +103,18 @@ module Html2rss
           end
         end
 
-        def extraction_empty_failure?(error)
-          defined?(::Html2rss::NoFeedItemsExtracted) && error_chain(error).any?(::Html2rss::NoFeedItemsExtracted)
+        def failure_payload(error, decision)
+          { message: client_message_for(error, decision), code: resolve_error_code(error, decision) }
+            .merge(failure_metadata(error, decision))
         end
 
-        def failure_payload(error)
-          { message: client_message_for(error), code: resolve_error_code(error) }.merge(failure_metadata(error))
-        end
-
-        def failure_metadata(error)
+        def failure_metadata(error, decision)
+          return INPUT_META.merge(kind: decision.kind) if decision
           return AUTH_META if error.is_a?(UnauthorizedError)
-          return INPUT_META if input_failure?(error)
+          return INPUT_META if error.is_a?(BadRequestError) || error.is_a?(ForbiddenError)
           return SERVER_META if error.is_a?(HealthCheckFailedError)
 
           RETRY_META.merge(kind: error_kind(error))
-        end
-
-        def input_failure?(error)
-          extraction_empty_failure?(error) || error.is_a?(BadRequestError) || error.is_a?(ForbiddenError)
         end
 
         def error_kind(error)
@@ -129,7 +123,7 @@ module Html2rss
           elsif error.is_a?(GatewayTimeoutError) || gateway_timeout?(error)
             'network'
           else
-            error_chain(error).any? { |e| NETWORK_ERRORS.include?(e.class) } ? 'network' : 'server'
+            ErrorClassifier.error_chain(error).any? { |e| NETWORK_ERRORS.include?(e.class) } ? 'network' : 'server'
           end
         end
 
@@ -139,15 +133,6 @@ module Html2rss
 
         def gateway_timeout?(error)
           error.is_a?(Timeout::Error) || error.is_a?(Errno::ETIMEDOUT)
-        end
-
-        def error_chain(error)
-          chain = []
-          while error && chain.none? { |e| e.equal?(error) }
-            chain << error
-            error = error.respond_to?(:cause) ? error.cause : nil
-          end
-          chain
         end
 
         def write_internal_error_log(request, error)

--- a/app/web/feeds/service.rb
+++ b/app/web/feeds/service.rb
@@ -31,7 +31,7 @@ module Html2rss
             success_result(feed, resolved_source, cache_key)
           rescue StandardError => error
             decision = ErrorClassifier.classify(error)
-            return empty_result(error, resolved_source, cache_key) if decision
+            return empty_result(error, resolved_source, cache_key) if decision&.cacheable
 
             error_result(error, resolved_source, cache_key)
           end

--- a/app/web/feeds/service.rb
+++ b/app/web/feeds/service.rb
@@ -30,7 +30,8 @@ module Html2rss
             feed = Html2rss.feed(resolved_source.generator_input)
             success_result(feed, resolved_source, cache_key)
           rescue StandardError => error
-            return empty_result(error, resolved_source, cache_key) if extraction_empty_error?(error)
+            decision = ErrorClassifier.classify(error)
+            return empty_result(error, resolved_source, cache_key) if decision
 
             error_result(error, resolved_source, cache_key)
           end
@@ -101,7 +102,7 @@ module Html2rss
             )
           end
 
-          # @param error [Html2rss::NoFeedItemsExtracted]
+          # @param error [StandardError]
           # @param resolved_source [Html2rss::Web::Feeds::Contracts::ResolvedSource]
           # @param cache_key [String]
           # @return [Html2rss::Web::Feeds::Contracts::RenderResult]
@@ -115,30 +116,6 @@ module Html2rss
               error_message: error.message,
               error_kind: :extraction_empty
             )
-          end
-
-          # @param error [StandardError]
-          # @return [Boolean]
-          def extraction_empty_error?(error)
-            return false unless defined?(::Html2rss::NoFeedItemsExtracted)
-
-            error_chain(error).any?(::Html2rss::NoFeedItemsExtracted)
-          end
-
-          # @param error [StandardError, nil]
-          # @return [Array<StandardError>]
-          def error_chain(error)
-            errors = []
-            seen = {}.compare_by_identity
-            current = error
-
-            while current && !seen[current]
-              errors << current
-              seen[current] = true
-              current = current.respond_to?(:cause) ? current.cause : nil
-            end
-
-            errors
           end
 
           # @param resolved_source [Html2rss::Web::Feeds::Contracts::ResolvedSource]

--- a/app/web/security/auth.rb
+++ b/app/web/security/auth.rb
@@ -28,20 +28,20 @@ module Html2rss
         # @param expires_in [Integer] seconds (default: 10 years)
         # @return [String, nil] signed feed token when generation succeeds.
         def generate_feed_token(username, url, strategy: nil, expires_in: FeedToken::DEFAULT_EXPIRY)
-          token = FeedToken.create_with_validation(
+          token = FeedToken::Signer.create(
             username: username,
             url: url,
             strategy: strategy,
             expires_in: expires_in,
             secret_key: secret_key
           )
-          token&.encode
+          token && FeedToken::Codec.encode(token)
         end
 
         # @param token [String]
         # @return [Html2rss::Web::FeedToken, nil]
         def validate_and_decode_feed_token(token)
-          decoded = FeedToken.decode(token)
+          decoded = FeedToken::Codec.decode(token)
           return unless decoded
 
           with_validated_token(token, decoded.url) { |validated| validated }
@@ -107,7 +107,7 @@ module Html2rss
         def with_validated_token(feed_token, url)
           return nil unless feed_token && url
 
-          token = FeedToken.validate_and_decode(feed_token, url, secret_key)
+          token = FeedToken::Signer.validate(feed_token, url, secret_key)
           assign_request_context_strategy(token&.strategy)
           SecurityLogger.log_token_usage(feed_token, url, !token.nil?)
           return nil unless token

--- a/app/web/security/auth.rb
+++ b/app/web/security/auth.rb
@@ -44,7 +44,7 @@ module Html2rss
           decoded = FeedToken::Codec.decode(token)
           return unless decoded
 
-          with_validated_token(token, decoded.url) { |validated| validated }
+          with_validated_token(token, decoded.url, decoded: decoded) { |validated| validated }
         end
 
         private
@@ -102,12 +102,17 @@ module Html2rss
         #
         # @param feed_token [String, nil]
         # @param url [String, nil]
+        # @param decoded [Html2rss::Web::FeedToken, nil] optional pre-decoded token
         # @yieldparam token [Html2rss::Web::FeedToken]
         # @return [Object, nil] block result when valid, otherwise nil.
-        def with_validated_token(feed_token, url)
+        def with_validated_token(feed_token, url, decoded: nil)
           return nil unless feed_token && url
 
-          token = FeedToken::Signer.validate(feed_token, url, secret_key)
+          token = if decoded
+                    FeedToken::Signer.validate_decoded(decoded, url, secret_key)
+                  else
+                    FeedToken::Signer.validate(feed_token, url, secret_key)
+                  end
           assign_request_context_strategy(token&.strategy)
           SecurityLogger.log_token_usage(feed_token, url, !token.nil?)
           return nil unless token

--- a/app/web/security/feed_token.rb
+++ b/app/web/security/feed_token.rb
@@ -1,63 +1,13 @@
 # frozen_string_literal: true
 
-require 'base64'
-require 'json'
-require 'openssl'
-require 'zlib'
-
 module Html2rss
-  module Web # rubocop:disable Metrics/ModuleLength
+  module Web
     ##
-    # Immutable feed token value object with encoding and validation helpers.
+    # Immutable feed-token value object.
+    #
+    # Wire encoding lives in {FeedToken::Codec}; HMAC creation and checks live
+    # in {FeedToken::Signer}.
     FeedToken = Data.define(:username, :url, :expires_at, :signature, :strategy) do
-      # @param username [String]
-      # @param url [String]
-      # @param secret_key [String]
-      # @param strategy [String, nil]
-      # @param expires_in [Integer]
-      # @return [Html2rss::Web::FeedToken, nil]
-      def self.create_with_validation(username:, url:, secret_key:, strategy: nil,
-                                      expires_in: Html2rss::Web::FeedToken::DEFAULT_EXPIRY)
-        return unless valid_inputs?(username, url, secret_key, strategy)
-
-        expires_at = Time.now.to_i + expires_in.to_i
-        signature = generate_signature(secret_key, build_payload(username, url, expires_at, strategy))
-        new(username:, url:, expires_at:, signature:, strategy:)
-      end
-
-      # @param encoded_token [String, nil]
-      # @return [Html2rss::Web::FeedToken, nil]
-      def self.decode(encoded_token)
-        return unless encoded_token
-
-        token_data = parse_token_data(encoded_token)
-        return unless valid_token_data?(token_data)
-
-        decoded_token(token_data)
-      rescue JSON::ParserError, ArgumentError, Zlib::DataError, Zlib::BufError
-        nil
-      end
-
-      # @param encoded_token [String, nil]
-      # @param expected_url [String, nil]
-      # @param secret_key [String]
-      # @return [Html2rss::Web::FeedToken, nil]
-      def self.validate_and_decode(encoded_token, expected_url, secret_key)
-        token = decode(encoded_token)
-        return unless token
-        return unless token.valid_signature?(secret_key)
-        return unless token.valid_for_url?(expected_url)
-        return if token.expired?
-
-        token
-      end
-
-      # @return [String]
-      def encode
-        compressed = Zlib::Deflate.deflate(build_token_data.to_json)
-        Base64.urlsafe_encode64(compressed)
-      end
-
       # @return [Boolean]
       def expired?
         Time.now.to_i > expires_at
@@ -68,132 +18,8 @@ module Html2rss
       def valid_for_url?(candidate_url)
         url == candidate_url
       end
-
-      # @param secret_key [String]
-      # @return [Boolean]
-      def valid_signature?(secret_key)
-        return false unless secret_key.is_a?(String) && !secret_key.empty?
-
-        expected_signature = OpenSSL::HMAC.hexdigest(
-          Html2rss::Web::FeedToken::HMAC_ALGORITHM,
-          secret_key,
-          JSON.generate(payload_for_signature)
-        )
-        signatures_match?(signature, expected_signature)
-      end
-
-      private
-
-      # @return [Hash{Symbol=>Object}]
-      def payload_for_signature
-        payload = { username:, url:, expires_at: }
-        payload[:strategy] = strategy if strategy
-        payload
-      end
-
-      # @return [Hash{Symbol=>Object}]
-      def build_token_data
-        payload = { u: username, l: url, e: expires_at }
-        payload[:t] = strategy if strategy
-        { p: payload, s: signature }
-      end
-
-      # @param first [String, nil]
-      # @param second [String, nil]
-      # @return [Boolean]
-      def signatures_match?(first, second)
-        return false unless first && second && first.bytesize == second.bytesize
-
-        first.each_byte.zip(second.each_byte).reduce(0) { |acc, (a, b)| acc | (a ^ b) }.zero?
-      end
-
-      class << self
-        private
-
-        # @param username [String]
-        # @param url [String]
-        # @param expires_at [Integer]
-        # @param strategy [String, nil]
-        # @return [Hash{Symbol=>Object}]
-        def build_payload(username, url, expires_at, strategy)
-          payload = { username:, url:, expires_at: }
-          payload[:strategy] = strategy if strategy
-          payload
-        end
-
-        # @param secret_key [String]
-        # @param payload [Hash, String]
-        # @return [String]
-        def generate_signature(secret_key, payload)
-          data = payload.is_a?(String) ? payload : JSON.generate(payload)
-          OpenSSL::HMAC.hexdigest(Html2rss::Web::FeedToken::HMAC_ALGORITHM, secret_key, data)
-        end
-
-        # @param encoded_token [String]
-        # @return [Hash{Symbol=>Object}]
-        def parse_token_data(encoded_token)
-          inflated = Zlib::Inflate.inflate(Base64.urlsafe_decode64(encoded_token))
-          JSON.parse(inflated, symbolize_names: true)
-        end
-
-        # @param token_data [Hash{Symbol=>Object}]
-        # @return [Html2rss::Web::FeedToken]
-        def decoded_token(token_data)
-          payload = token_data[:p]
-          new(
-            username: payload[:u],
-            url: payload[:l],
-            expires_at: payload[:e],
-            signature: token_data[:s],
-            strategy: payload[:t]
-          )
-        end
-
-        # @param token_data [Object]
-        # @return [Boolean]
-        def valid_token_data?(token_data)
-          return false unless token_data.is_a?(Hash)
-
-          payload = token_data[:p]
-          signature = token_data[:s]
-          payload.is_a?(Hash) && signature.is_a?(String) && !signature.empty? &&
-            Html2rss::Web::FeedToken::COMPRESSED_PAYLOAD_KEYS.all? { |key| payload[key] }
-        end
-
-        # @param username [Object]
-        # @param url [Object]
-        # @param secret_key [Object]
-        # @param strategy [Object]
-        # @return [Boolean]
-        def valid_inputs?(username, url, secret_key, strategy)
-          valid_username?(username) && UrlValidator.valid_url?(url) && valid_secret_key?(secret_key) &&
-            valid_strategy?(strategy)
-        end
-
-        # @param username [Object]
-        # @return [Boolean]
-        def valid_username?(username)
-          username.is_a?(String) && !username.empty? && username.length <= 100 && username.match?(/\A[a-zA-Z0-9_-]+\z/)
-        end
-
-        # @param secret_key [Object]
-        # @return [Boolean]
-        def valid_secret_key?(secret_key)
-          secret_key.is_a?(String) && !secret_key.empty?
-        end
-
-        # @param strategy [Object]
-        # @return [Boolean]
-        def valid_strategy?(strategy)
-          return true if strategy.nil?
-
-          strategy.is_a?(String) && !strategy.empty? && strategy.length <= 50 && strategy.match?(/\A[a-z0-9_]+\z/)
-        end
-      end
     end
 
     FeedToken::DEFAULT_EXPIRY = 315_360_000
-    FeedToken::HMAC_ALGORITHM = 'SHA256'
-    FeedToken::COMPRESSED_PAYLOAD_KEYS = %i[u l e].freeze
   end
 end

--- a/app/web/security/feed_token/codec.rb
+++ b/app/web/security/feed_token/codec.rb
@@ -12,8 +12,6 @@ module Html2rss
       #
       # Wire shape is JSON +zlib+base64 of +{ p: { u, l, e, t? }, s }+.
       module Codec
-        COMPRESSED_PAYLOAD_KEYS = %i[u l e].freeze
-
         class << self
           # @param token [Html2rss::Web::FeedToken]
           # @return [String]
@@ -70,10 +68,18 @@ module Html2rss
           def valid_token_data?(token_data)
             return false unless token_data.is_a?(Hash)
 
-            payload = token_data[:p]
             signature = token_data[:s]
-            payload.is_a?(Hash) && signature.is_a?(String) && !signature.empty? &&
-              COMPRESSED_PAYLOAD_KEYS.all? { |key| payload[key] }
+            signature.is_a?(String) && !signature.empty? && valid_payload?(token_data[:p])
+          end
+
+          # @param payload [Object]
+          # @return [Boolean]
+          def valid_payload?(payload)
+            payload.is_a?(Hash) &&
+              payload[:u].is_a?(String) &&
+              payload[:l].is_a?(String) &&
+              payload[:e].is_a?(Integer) &&
+              (payload[:t].nil? || payload[:t].is_a?(String))
           end
         end
       end

--- a/app/web/security/feed_token/codec.rb
+++ b/app/web/security/feed_token/codec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'base64'
+require 'json'
+require 'zlib'
+
+module Html2rss
+  module Web
+    class FeedToken
+      ##
+      # zlib + URL-safe Base64 codec for feed-token wire payloads.
+      #
+      # Wire shape is JSON +zlib+base64 of +{ p: { u, l, e, t? }, s }+.
+      module Codec
+        COMPRESSED_PAYLOAD_KEYS = %i[u l e].freeze
+
+        class << self
+          # @param token [Html2rss::Web::FeedToken]
+          # @return [String]
+          def encode(token)
+            compressed = Zlib::Deflate.deflate(wire_document(token).to_json)
+            Base64.urlsafe_encode64(compressed)
+          end
+
+          # @param encoded_token [String, nil]
+          # @return [Html2rss::Web::FeedToken, nil]
+          def decode(encoded_token)
+            return unless encoded_token
+
+            token_data = parse_token_data(encoded_token)
+            return unless valid_token_data?(token_data)
+
+            decoded_token(token_data)
+          rescue JSON::ParserError, ArgumentError, Zlib::DataError, Zlib::BufError
+            nil
+          end
+
+          private
+
+          # @param token [Html2rss::Web::FeedToken]
+          # @return [Hash{Symbol=>Object}]
+          def wire_document(token)
+            payload = { u: token.username, l: token.url, e: token.expires_at }
+            payload[:t] = token.strategy if token.strategy
+            { p: payload, s: token.signature }
+          end
+
+          # @param encoded_token [String]
+          # @return [Hash{Symbol=>Object}]
+          def parse_token_data(encoded_token)
+            inflated = Zlib::Inflate.inflate(Base64.urlsafe_decode64(encoded_token))
+            JSON.parse(inflated, symbolize_names: true)
+          end
+
+          # @param token_data [Hash{Symbol=>Object}]
+          # @return [Html2rss::Web::FeedToken]
+          def decoded_token(token_data)
+            payload = token_data[:p]
+            FeedToken.new(
+              username: payload[:u],
+              url: payload[:l],
+              expires_at: payload[:e],
+              signature: token_data[:s],
+              strategy: payload[:t]
+            )
+          end
+
+          # @param token_data [Object]
+          # @return [Boolean]
+          def valid_token_data?(token_data)
+            return false unless token_data.is_a?(Hash)
+
+            payload = token_data[:p]
+            signature = token_data[:s]
+            payload.is_a?(Hash) && signature.is_a?(String) && !signature.empty? &&
+              COMPRESSED_PAYLOAD_KEYS.all? { |key| payload[key] }
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/web/security/feed_token/signer.rb
+++ b/app/web/security/feed_token/signer.rb
@@ -31,7 +31,16 @@ module Html2rss
           # @param secret_key [String]
           # @return [Html2rss::Web::FeedToken, nil]
           def validate(encoded_token, expected_url, secret_key)
-            token = Codec.decode(encoded_token)
+            validate_decoded(Codec.decode(encoded_token), expected_url, secret_key)
+          end
+
+          # Validates signature, URL binding, and expiry for an already-decoded token.
+          #
+          # @param token [Html2rss::Web::FeedToken, nil]
+          # @param expected_url [String, nil]
+          # @param secret_key [String]
+          # @return [Html2rss::Web::FeedToken, nil]
+          def validate_decoded(token, expected_url, secret_key)
             return unless token
             return unless valid_signature?(token, secret_key)
             return unless token.valid_for_url?(expected_url)

--- a/app/web/security/feed_token/signer.rb
+++ b/app/web/security/feed_token/signer.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'openssl'
+
+module Html2rss
+  module Web
+    class FeedToken
+      ##
+      # HMAC-SHA256 creation and verification for feed tokens.
+      module Signer
+        HMAC_ALGORITHM = 'SHA256'
+
+        class << self
+          # @param username [String]
+          # @param url [String]
+          # @param secret_key [String]
+          # @param strategy [String, nil]
+          # @param expires_in [Integer]
+          # @return [Html2rss::Web::FeedToken, nil]
+          def create(username:, url:, secret_key:, strategy: nil, expires_in: FeedToken::DEFAULT_EXPIRY)
+            return unless valid_inputs?(username, url, secret_key, strategy)
+
+            expires_at = Time.now.to_i + expires_in.to_i
+            signature = sign(secret_key, signature_payload(username, url, expires_at, strategy))
+            FeedToken.new(username:, url:, expires_at:, signature:, strategy:)
+          end
+
+          # @param encoded_token [String, nil]
+          # @param expected_url [String, nil]
+          # @param secret_key [String]
+          # @return [Html2rss::Web::FeedToken, nil]
+          def validate(encoded_token, expected_url, secret_key)
+            token = Codec.decode(encoded_token)
+            return unless token
+            return unless valid_signature?(token, secret_key)
+            return unless token.valid_for_url?(expected_url)
+            return if token.expired?
+
+            token
+          end
+
+          # @param token [Html2rss::Web::FeedToken]
+          # @param secret_key [String]
+          # @return [Boolean]
+          def valid_signature?(token, secret_key)
+            return false unless secret_key.is_a?(String) && !secret_key.empty?
+
+            expected_signature = sign(secret_key, signature_payload(
+                                                    token.username, token.url, token.expires_at, token.strategy
+                                                  ))
+            signatures_match?(token.signature, expected_signature)
+          end
+
+          private
+
+          # @param username [String]
+          # @param url [String]
+          # @param expires_at [Integer]
+          # @param strategy [String, nil]
+          # @return [Hash{Symbol=>Object}]
+          def signature_payload(username, url, expires_at, strategy)
+            payload = { username:, url:, expires_at: }
+            payload[:strategy] = strategy if strategy
+            payload
+          end
+
+          # @param secret_key [String]
+          # @param payload [Hash, String]
+          # @return [String]
+          def sign(secret_key, payload)
+            data = payload.is_a?(String) ? payload : JSON.generate(payload)
+            OpenSSL::HMAC.hexdigest(HMAC_ALGORITHM, secret_key, data)
+          end
+
+          # @param first [String, nil]
+          # @param second [String, nil]
+          # @return [Boolean]
+          def signatures_match?(first, second)
+            return false unless first && second && first.bytesize == second.bytesize
+
+            first.each_byte.zip(second.each_byte).reduce(0) { |acc, (a, b)| acc | (a ^ b) }.zero?
+          end
+
+          # @param username [Object]
+          # @param url [Object]
+          # @param secret_key [Object]
+          # @param strategy [Object]
+          # @return [Boolean]
+          def valid_inputs?(username, url, secret_key, strategy)
+            valid_username?(username) && UrlValidator.valid_url?(url) && valid_secret_key?(secret_key) &&
+              valid_strategy?(strategy)
+          end
+
+          # @param username [Object]
+          # @return [Boolean]
+          def valid_username?(username)
+            username.is_a?(String) && !username.empty? && username.length <= 100 &&
+              username.match?(/\A[a-zA-Z0-9_-]+\z/)
+          end
+
+          # @param secret_key [Object]
+          # @return [Boolean]
+          def valid_secret_key?(secret_key)
+            secret_key.is_a?(String) && !secret_key.empty?
+          end
+
+          # @param strategy [Object]
+          # @return [Boolean]
+          def valid_strategy?(strategy)
+            return true if strategy.nil?
+
+            strategy.is_a?(String) && !strategy.empty? && strategy.length <= 50 && strategy.match?(/\A[a-z0-9_]+\z/)
+          end
+        end
+      end
+    end
+  end
+end

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -31,13 +31,11 @@ const mockCreatedFeedResult = {
     json_public_url: '/api/v1/feeds/generated-token.json',
   },
   preview: {
+    status: 'created' as const,
     items: [],
-    error: undefined,
     isLoading: true,
   },
-  workflowState: 'created' as const,
   warnings: [],
-  retry: undefined,
 };
 
 describe('App', () => {
@@ -246,10 +244,10 @@ describe('App', () => {
           json_public_url: '/api/v1/feeds/example-token.json',
         },
         preview: {
+          status: 'preview_failed' as const,
           items: [],
           isLoading: false,
         },
-        workflowState: 'preview_failed' as const,
         warnings: [
           {
             code: 'preview_unavailable',
@@ -258,7 +256,6 @@ describe('App', () => {
             nextAction: 'none',
           },
         ],
-        retry: undefined,
       },
       error: undefined,
       convertFeed: mockConvertFeed,
@@ -288,6 +285,31 @@ describe('App', () => {
       isConverting: false,
       result: undefined,
       error: {
+        kind: 'server',
+        code: 'INTERNAL_SERVER_ERROR',
+        retryable: true,
+        nextAction: 'retry',
+        retryAction: 'primary',
+        message: 'Access denied',
+      },
+      convertFeed: mockConvertFeed,
+      clearError: mockClearConversionError,
+      clearResult: mockClearResult,
+      retryPreviewFetch: mockRetryPreviewFetch,
+    });
+
+    render(<App />);
+
+    expect(document.querySelector('.form-shell')).toHaveAttribute('data-state', 'error');
+    expect(screen.getByText("Couldn't create feed yet")).toBeInTheDocument();
+    expect(screen.getByText('Access denied')).toBeInTheDocument();
+  });
+
+  it('maps auth conversion failures onto the token_prompt view model', () => {
+    mockUseFeedConversion.mockReturnValue({
+      isConverting: false,
+      result: undefined,
+      error: {
         kind: 'auth',
         code: 'UNAUTHORIZED',
         retryable: false,
@@ -303,7 +325,8 @@ describe('App', () => {
 
     render(<App />);
 
-    expect(screen.getByText("Couldn't create feed yet")).toBeInTheDocument();
+    expect(document.querySelector('.form-shell')).toHaveAttribute('data-state', 'token_prompt');
+    expect(screen.getByText('Enter access token')).toBeInTheDocument();
     expect(screen.getByText('Access denied')).toBeInTheDocument();
   });
 

--- a/frontend/src/__tests__/ResultDisplay.test.tsx
+++ b/frontend/src/__tests__/ResultDisplay.test.tsx
@@ -1,11 +1,13 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/preact';
 import { ResultDisplay } from '../components/ResultDisplay';
+import type { AppViewModel } from '../appViewModel';
 
 describe('ResultDisplay', () => {
   const mockOnCreateAnother = vi.fn();
   const mockOnRetryPreview = vi.fn();
-  const mockResult = {
+  const mockViewModel: Extract<AppViewModel, { kind: 'result' }> = {
+    kind: 'result',
     feed: {
       id: 'test-id',
       name: 'Test Feed',
@@ -17,6 +19,7 @@ describe('ResultDisplay', () => {
       updated_at: '2024-01-01T00:00:00Z',
     },
     preview: {
+      status: 'preview_ready',
       items: [
         {
           title: 'Item One',
@@ -27,7 +30,6 @@ describe('ResultDisplay', () => {
       ],
       isLoading: false,
     },
-    workflowState: 'preview_ready' as const,
     warnings: [],
   };
 
@@ -36,9 +38,10 @@ describe('ResultDisplay', () => {
   });
 
   it('renders ready feed actions and preview cards', async () => {
-    const resultWithMultiplePreviewItems = {
-      ...mockResult,
+    const viewModelWithMultiplePreviewItems = {
+      ...mockViewModel,
       preview: {
+        status: 'preview_ready' as const,
         items: [
           {
             title: 'Item One',
@@ -71,8 +74,7 @@ describe('ResultDisplay', () => {
 
     render(
       <ResultDisplay
-        result={resultWithMultiplePreviewItems}
-        workflowState="result"
+        viewModel={viewModelWithMultiplePreviewItems}
         onCreateAnother={mockOnCreateAnother}
         onRetryPreview={mockOnRetryPreview}
       />
@@ -97,12 +99,10 @@ describe('ResultDisplay', () => {
   it('renders preview loading as frontend-owned progress', () => {
     render(
       <ResultDisplay
-        result={{
-          ...mockResult,
-          workflowState: 'preview_loading',
-          preview: { items: [], isLoading: true },
+        viewModel={{
+          ...mockViewModel,
+          preview: { status: 'preview_loading', items: [], isLoading: true },
         }}
-        workflowState="result"
         onCreateAnother={mockOnCreateAnother}
         onRetryPreview={mockOnRetryPreview}
       />
@@ -116,10 +116,9 @@ describe('ResultDisplay', () => {
   it('lets retryable preview failures retry preview only', () => {
     render(
       <ResultDisplay
-        result={{
-          ...mockResult,
-          workflowState: 'preview_failed',
-          preview: { items: [], isLoading: false },
+        viewModel={{
+          ...mockViewModel,
+          preview: { status: 'preview_failed', items: [], isLoading: false },
           warnings: [
             {
               code: 'PREVIEW_HTTP_503',
@@ -129,7 +128,6 @@ describe('ResultDisplay', () => {
             },
           ],
         }}
-        workflowState="result"
         onCreateAnother={mockOnCreateAnother}
         onRetryPreview={mockOnRetryPreview}
       />
@@ -143,8 +141,7 @@ describe('ResultDisplay', () => {
   it('calls onCreateAnother and copies feed URL', async () => {
     render(
       <ResultDisplay
-        result={mockResult}
-        workflowState="result"
+        viewModel={mockViewModel}
         onCreateAnother={mockOnCreateAnother}
         onRetryPreview={mockOnRetryPreview}
       />

--- a/frontend/src/__tests__/appViewModel.test.ts
+++ b/frontend/src/__tests__/appViewModel.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { deriveAppViewModel } from '../appViewModel';
+
+const emptyErrors = { url: '', form: '' };
+
+describe('deriveAppViewModel', () => {
+  it('returns create by default', () => {
+    expect(
+      deriveAppViewModel({
+        feedFieldErrors: emptyErrors,
+        isConverting: false,
+        routeKind: 'create',
+        tokenError: '',
+      })
+    ).toEqual({ kind: 'create' });
+  });
+
+  it('nests preview under the result variant', () => {
+    const viewModel = deriveAppViewModel({
+      feedFieldErrors: emptyErrors,
+      isConverting: false,
+      routeKind: 'result',
+      tokenError: '',
+      result: {
+        feed: {
+          id: 'feed-1',
+          name: 'Example',
+          url: 'https://example.com',
+          feed_token: 'token',
+          public_url: '/feed',
+          json_public_url: '/feed.json',
+          created_at: '2024-01-01T00:00:00Z',
+          updated_at: '2024-01-01T00:00:00Z',
+        },
+        preview: { status: 'preview_ready', items: [], isLoading: false },
+        warnings: [],
+      },
+    });
+
+    expect(viewModel).toMatchObject({
+      kind: 'result',
+      preview: { status: 'preview_ready' },
+    });
+  });
+
+  it('maps auth conversion failures to token_prompt', () => {
+    expect(
+      deriveAppViewModel({
+        feedFieldErrors: emptyErrors,
+        isConverting: false,
+        routeKind: 'create',
+        tokenError: '',
+        conversionError: {
+          kind: 'auth',
+          code: 'UNAUTHORIZED',
+          retryable: false,
+          nextAction: 'enter_token',
+          retryAction: 'none',
+          message: 'Access denied',
+        },
+      })
+    ).toMatchObject({
+      kind: 'token_prompt',
+      error: { code: 'UNAUTHORIZED' },
+    });
+  });
+
+  it('maps submitting and corrective input failures', () => {
+    expect(
+      deriveAppViewModel({
+        feedFieldErrors: emptyErrors,
+        isConverting: true,
+        routeKind: 'create',
+        tokenError: '',
+      })
+    ).toEqual({ kind: 'submitting' });
+
+    expect(
+      deriveAppViewModel({
+        feedFieldErrors: { url: '', form: 'Bad url' },
+        isConverting: false,
+        routeKind: 'create',
+        tokenError: '',
+        conversionError: {
+          kind: 'input',
+          code: 'INVALID_INPUT',
+          retryable: false,
+          nextAction: 'correct_input',
+          retryAction: 'none',
+          message: 'Bad url',
+        },
+      })
+    ).toMatchObject({ kind: 'error', message: 'Bad url', errorKind: 'input' });
+  });
+});

--- a/frontend/src/__tests__/appViewModel.test.ts
+++ b/frontend/src/__tests__/appViewModel.test.ts
@@ -92,4 +92,15 @@ describe('deriveAppViewModel', () => {
       })
     ).toMatchObject({ kind: 'error', message: 'Bad url', errorKind: 'input' });
   });
+
+  it('returns submitting on token route while converting', () => {
+    expect(
+      deriveAppViewModel({
+        feedFieldErrors: emptyErrors,
+        isConverting: true,
+        routeKind: 'token',
+        tokenError: '',
+      })
+    ).toEqual({ kind: 'submitting' });
+  });
 });

--- a/frontend/src/__tests__/feedCreationError.test.ts
+++ b/frontend/src/__tests__/feedCreationError.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildLocalError,
+  normalizeFeedCreationError,
+  normalizeFeedCreationErrorFromResponse,
+} from '../feeds/feedCreationError';
+
+describe('feedCreationError', () => {
+  it('normalizes structured response envelopes without parsing message text', () => {
+    const error = normalizeFeedCreationErrorFromResponse(401, {
+      kind: 'auth',
+      code: 'UNAUTHORIZED',
+      retryable: false,
+      next_action: 'enter_token',
+      retry_action: 'none',
+      message: 'Authentication required',
+    });
+
+    expect(error).toMatchObject({
+      kind: 'auth',
+      code: 'UNAUTHORIZED',
+      retryable: false,
+      nextAction: 'enter_token',
+      retryAction: 'none',
+      message: 'Authentication required',
+      status: 401,
+    });
+  });
+
+  it('derives fallbacks from HTTP status when envelope fields are missing', () => {
+    const error = normalizeFeedCreationErrorFromResponse(503, undefined);
+
+    expect(error).toMatchObject({
+      kind: 'network',
+      code: 'TRANSIENT_ERROR',
+      retryable: true,
+      nextAction: 'retry',
+      retryAction: 'primary',
+      status: 503,
+    });
+  });
+
+  it('maps extraction-empty envelopes to corrective input errors', () => {
+    const error = normalizeFeedCreationErrorFromResponse(422, {
+      kind: 'input',
+      code: 'NO_FEED_ITEMS_EXTRACTED',
+      retryable: false,
+      next_action: 'correct_input',
+      retry_action: 'none',
+      message: 'Could not extract feed items.',
+    });
+
+    expect(error).toMatchObject({
+      kind: 'input',
+      code: 'NO_FEED_ITEMS_EXTRACTED',
+      nextAction: 'correct_input',
+      retryAction: 'none',
+      retryable: false,
+    });
+  });
+
+  it('passes through FeedCreationError instances and wraps unknown errors', () => {
+    const local = buildLocalError('Invalid URL format.', 'input', 'correct_input');
+    expect(normalizeFeedCreationError(local)).toBe(local);
+
+    expect(normalizeFeedCreationError(new Error('offline'))).toMatchObject({
+      kind: 'network',
+      code: 'NETWORK_ERROR',
+      message: 'offline',
+      nextAction: 'retry',
+    });
+
+    expect(normalizeFeedCreationError('boom')).toMatchObject({
+      kind: 'server',
+      code: 'UNKNOWN_ERROR',
+    });
+  });
+});

--- a/frontend/src/__tests__/previewHydration.test.ts
+++ b/frontend/src/__tests__/previewHydration.test.ts
@@ -46,7 +46,7 @@ describe('previewHydration', () => {
       { title: 'Five' },
       { title: 'Six' },
       { title: '' },
-      null,
+      undefined,
     ]);
 
     expect(items).toHaveLength(5);

--- a/frontend/src/__tests__/previewHydration.test.ts
+++ b/frontend/src/__tests__/previewHydration.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type SpyInstance } from 'vitest';
+import {
+  buildCreatedFeedResult,
+  loadPreviewItems,
+  loadPreviewItemsWithRetry,
+  normalizePreviewItems,
+} from '../feeds/previewHydration';
+
+const feed = {
+  id: 'feed-1',
+  name: 'Example Feed',
+  url: 'https://example.com/articles',
+  feed_token: 'feed-token-1',
+  public_url: '/api/v1/feeds/feed-token-1',
+  json_public_url: '/api/v1/feeds/feed-token-1.json',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+};
+
+describe('previewHydration', () => {
+  let fetchMock: SpyInstance;
+
+  beforeEach(() => {
+    fetchMock = vi.spyOn(globalThis, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchMock.mockRestore();
+    vi.useRealTimers();
+  });
+
+  it('builds an initial created result with nested preview status', () => {
+    expect(buildCreatedFeedResult(feed)).toMatchObject({
+      feed,
+      preview: { status: 'created', items: [], isLoading: false },
+      warnings: [],
+    });
+  });
+
+  it('normalizes json feed items and caps at five', () => {
+    const items = normalizePreviewItems([
+      { title: 'One', content_text: 'A', date_published: '2024-01-01', url: 'https://example.com/1' },
+      { title: 'Two', description: 'B', publishedLabel: 'Jan 2' },
+      { title: 'Three' },
+      { title: 'Four' },
+      { title: 'Five' },
+      { title: 'Six' },
+      { title: '' },
+      null,
+    ]);
+
+    expect(items).toHaveLength(5);
+    expect(items[0]).toMatchObject({
+      title: 'One',
+      excerpt: 'A',
+      publishedLabel: '2024-01-01',
+      url: 'https://example.com/1',
+    });
+  });
+
+  it('marks non-transient preview HTTP failures as non-retryable', async () => {
+    fetchMock.mockResolvedValueOnce(new Response('', { status: 422 }));
+
+    await expect(loadPreviewItems('/api/v1/feeds/feed-token-1.json')).resolves.toMatchObject({
+      status: 'preview_failed',
+      warnings: [{ code: 'PREVIEW_HTTP_422', retryable: false, nextAction: 'wait' }],
+    });
+  });
+
+  it('retries only transient preview failures', async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce(new Response('', { status: 503 }))
+      .mockResolvedValueOnce(
+        Response.json(
+          { items: [{ title: 'Preview item', content_text: 'Excerpt', date_published: '2024-01-02' }] },
+          { status: 200, headers: { 'Content-Type': 'application/feed+json' } }
+        )
+      );
+
+    const pending = loadPreviewItemsWithRetry('/api/v1/feeds/feed-token-1.json');
+    await vi.advanceTimersByTimeAsync(260);
+    await expect(pending).resolves.toMatchObject({
+      status: 'preview_ready',
+      items: [{ title: 'Preview item' }],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/__tests__/url.test.ts
+++ b/frontend/src/__tests__/url.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isNormalizedHttpUrl, normalizeUserUrl } from '../utils/url';
+
+describe('url', () => {
+  it('normalizes host-like values to https', () => {
+    expect(normalizeUserUrl('example.com/articles')).toBe('https://example.com/articles');
+    expect(normalizeUserUrl('//example.com')).toBe('https://example.com');
+  });
+
+  it('accepts only http(s) after normalization', () => {
+    expect(isNormalizedHttpUrl('example.com')).toBe(true);
+    expect(isNormalizedHttpUrl('https://example.com/path')).toBe(true);
+    expect(isNormalizedHttpUrl('ftp://example.com')).toBe(false);
+    expect(isNormalizedHttpUrl('not a url')).toBe(false);
+    expect(isNormalizedHttpUrl('')).toBe(false);
+  });
+});

--- a/frontend/src/__tests__/useFeedConversion.contract.test.ts
+++ b/frontend/src/__tests__/useFeedConversion.contract.test.ts
@@ -61,7 +61,7 @@ describe('useFeedConversion contract', () => {
     expect(receivedAuthorization).toBe('Bearer test-token-123');
     expect(result.current.error).toBeUndefined();
     expect(result.current.result?.feed.feed_token).toBe('generated-token');
-    await waitFor(() => expect(result.current.result?.workflowState).toBe('preview_ready'));
+    await waitFor(() => expect(result.current.result?.preview.status).toBe('preview_ready'));
     fetchSpy.mockRestore();
   });
 
@@ -178,7 +178,7 @@ describe('useFeedConversion contract', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.result?.workflowState).toBe('preview_failed');
+      expect(result.current.result?.preview.status).toBe('preview_failed');
       expect(result.current.result?.warnings[0]?.code).toBe('PREVIEW_HTTP_422');
     });
     fetchSpy.mockRestore();

--- a/frontend/src/__tests__/useFeedConversion.test.ts
+++ b/frontend/src/__tests__/useFeedConversion.test.ts
@@ -59,7 +59,7 @@ describe('useFeedConversion', () => {
     expect(fetchMock.mock.calls).toHaveLength(2);
 
     await waitFor(() => {
-      expect(result.current.result?.workflowState).toBe('preview_ready');
+      expect(result.current.result?.preview.status).toBe('preview_ready');
       expect(result.current.result?.preview.items[0]?.title).toBe('Preview item');
     });
   });
@@ -81,7 +81,7 @@ describe('useFeedConversion', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.result?.workflowState).toBe('preview_ready');
+      expect(result.current.result?.preview.status).toBe('preview_ready');
     });
     expect(fetchMock.mock.calls.filter((call) => String(call[0]) === '/api/v1/feeds').length).toBe(1);
     expect(
@@ -103,7 +103,7 @@ describe('useFeedConversion', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.result?.workflowState).toBe('preview_failed');
+      expect(result.current.result?.preview.status).toBe('preview_failed');
       expect(result.current.result?.warnings[0]).toMatchObject({
         code: 'PREVIEW_HTTP_422',
         retryable: false,
@@ -121,12 +121,12 @@ describe('useFeedConversion', () => {
     await act(async () => {
       await result.current.convertFeed('https://example.com/articles', 'token-123');
     });
-    await waitFor(() => expect(result.current.result?.workflowState).toBe('preview_failed'));
+    await waitFor(() => expect(result.current.result?.preview.status).toBe('preview_failed'));
 
     fetchMock.mockResolvedValueOnce(previewResponse());
     act(() => result.current.retryPreviewFetch());
 
-    await waitFor(() => expect(result.current.result?.workflowState).toBe('preview_ready'));
+    await waitFor(() => expect(result.current.result?.preview.status).toBe('preview_ready'));
     expect(fetchMock.mock.calls.filter((call) => String(call[0]) === '/api/v1/feeds').length).toBe(1);
   });
 });

--- a/frontend/src/api/contracts.ts
+++ b/frontend/src/api/contracts.ts
@@ -11,7 +11,7 @@ export interface FeedRecord {
   updated_at: string;
 }
 
-export type FeedWorkflowState = 'created' | 'preview_loading' | 'preview_ready' | 'preview_failed';
+export type FeedPreviewStatus = 'created' | 'preview_loading' | 'preview_ready' | 'preview_failed';
 export type FeedRetryAction = 'alternate' | 'primary' | 'none';
 export type FeedNextAction = 'enter_token' | 'correct_input' | 'retry' | 'wait' | 'none';
 
@@ -30,6 +30,7 @@ export interface FeedPreviewWarning {
 }
 
 export interface FeedPreviewState {
+  status: FeedPreviewStatus;
   items: FeedPreviewItem[];
   isLoading: boolean;
 }
@@ -37,7 +38,6 @@ export interface FeedPreviewState {
 export interface CreatedFeedResult {
   feed: FeedRecord;
   preview: FeedPreviewState;
-  workflowState: FeedWorkflowState;
   warnings: FeedPreviewWarning[];
 }
 

--- a/frontend/src/appViewModel.ts
+++ b/frontend/src/appViewModel.ts
@@ -58,6 +58,8 @@ export function deriveAppViewModel({
     };
   }
 
+  if (isConverting) return { kind: 'submitting' };
+
   if (routeKind === 'token' || tokenError) {
     return { kind: 'token_prompt', tokenError, error: conversionError };
   }
@@ -74,8 +76,6 @@ export function deriveAppViewModel({
       errorKind: conversionError?.kind,
     };
   }
-
-  if (isConverting) return { kind: 'submitting' };
 
   if (conversionError) {
     return {

--- a/frontend/src/appViewModel.ts
+++ b/frontend/src/appViewModel.ts
@@ -1,0 +1,90 @@
+import type {
+  CreatedFeedResult,
+  FeedCreationError,
+  FeedPreviewState,
+  FeedPreviewWarning,
+  FeedRecord,
+} from './api/contracts';
+
+export type AppViewModel =
+  | { kind: 'create' }
+  | { kind: 'submitting' }
+  | { kind: 'token_prompt'; tokenError: string; error?: FeedCreationError }
+  | {
+      kind: 'result';
+      feed: FeedRecord;
+      preview: FeedPreviewState;
+      warnings: FeedPreviewWarning[];
+    }
+  | {
+      kind: 'error';
+      message: string;
+      error?: FeedCreationError;
+      errorKind?: FeedCreationError['kind'];
+    };
+
+export function deriveAppViewModel({
+  conversionError,
+  feedFieldErrors,
+  isConverting,
+  routeKind,
+  tokenError,
+  tokenStateError,
+  metadataError,
+  result,
+}: {
+  conversionError?: FeedCreationError;
+  feedFieldErrors: { url: string; form: string };
+  isConverting: boolean;
+  routeKind: 'create' | 'token' | 'result';
+  tokenError: string;
+  tokenStateError?: string;
+  metadataError?: string;
+  result?: CreatedFeedResult;
+}): AppViewModel {
+  if (tokenStateError || metadataError) {
+    return {
+      kind: 'error',
+      message: metadataError ?? tokenStateError ?? 'Instance unavailable.',
+    };
+  }
+
+  if (routeKind === 'result' && result) {
+    return {
+      kind: 'result',
+      feed: result.feed,
+      preview: result.preview,
+      warnings: result.warnings,
+    };
+  }
+
+  if (routeKind === 'token' || tokenError) {
+    return { kind: 'token_prompt', tokenError, error: conversionError };
+  }
+
+  if (conversionError?.nextAction === 'enter_token' || conversionError?.kind === 'auth') {
+    return { kind: 'token_prompt', tokenError, error: conversionError };
+  }
+
+  if (feedFieldErrors.url || feedFieldErrors.form || conversionError?.nextAction === 'correct_input') {
+    return {
+      kind: 'error',
+      message: conversionError?.message || feedFieldErrors.form,
+      error: conversionError,
+      errorKind: conversionError?.kind,
+    };
+  }
+
+  if (isConverting) return { kind: 'submitting' };
+
+  if (conversionError) {
+    return {
+      kind: 'error',
+      message: conversionError.message,
+      error: conversionError,
+      errorKind: conversionError.kind,
+    };
+  }
+
+  return { kind: 'create' };
+}

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -95,8 +95,7 @@ export function App() {
 
   const feedCreation = metadata?.instance.feed_creation ?? DEFAULT_FEED_CREATION;
   const featuredFeeds = metadata?.instance.featured_feeds ?? [];
-  const submitDisabled =
-    isConverting || !feedCreation.enabled || viewModel.kind === 'token_prompt';
+  const submitDisabled = isConverting || !feedCreation.enabled || viewModel.kind === 'token_prompt';
 
   const setFeedField = (key: 'url', value: string) => {
     setFeedFormData((previous) => {

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -9,43 +9,11 @@ import { useFeedConversion } from '../hooks/useFeedConversion';
 import { useAppRoute } from '../routes/appRoute';
 import { clearFeedDraftState, loadFeedDraftState, saveFeedDraftState } from '../utils/feedWorkflowStorage';
 import { normalizeUserUrl } from '../utils/url';
-import type { WorkflowState } from './AppPanels';
+import { deriveAppViewModel } from '../appViewModel';
 import type { FeedCreationError } from '../api/contracts';
 
 const EMPTY_FEED_ERRORS = { url: '', form: '' };
 const DEFAULT_FEED_CREATION = { enabled: true, access_token_required: true };
-
-function deriveWorkflowState({
-  conversionError,
-  feedFieldErrors,
-  isConverting,
-  routeKind,
-  tokenError,
-  tokenStateError,
-  metadataError,
-}: {
-  conversionError?: FeedCreationError;
-  feedFieldErrors: { url: string; form: string };
-  isConverting: boolean;
-  routeKind: string;
-  tokenError: string;
-  tokenStateError?: string;
-  metadataError?: string;
-}): WorkflowState {
-  if (tokenStateError || metadataError) return 'error';
-  if (routeKind === 'token' || tokenError) return 'token_prompt';
-  if (conversionError?.nextAction === 'enter_token' || conversionError?.kind === 'auth')
-    return 'token_prompt';
-  if (routeKind === 'result') return 'result';
-  if (feedFieldErrors.url || feedFieldErrors.form || conversionError?.nextAction === 'correct_input') {
-    return 'error';
-  }
-  if (isConverting) return 'submitting';
-
-  if (conversionError) return 'error';
-
-  return 'create';
-}
 
 function BrandLockup({ onNavigateHome }: { onNavigateHome: () => void }) {
   return (
@@ -100,13 +68,13 @@ export function App() {
   const isTokenRoute = route.kind === 'token';
   const activeResult =
     route.kind === 'result' && result?.feed.feed_token === route.feedToken ? result : undefined;
-  let visibleRouteKind = 'create';
+  let visibleRouteKind: 'create' | 'token' | 'result' = 'create';
   if (activeResult) {
     visibleRouteKind = 'result';
   } else if (isTokenRoute) {
     visibleRouteKind = 'token';
   }
-  const workflowState: WorkflowState = deriveWorkflowState({
+  const viewModel = deriveAppViewModel({
     conversionError,
     feedFieldErrors,
     isConverting,
@@ -114,6 +82,7 @@ export function App() {
     tokenError,
     tokenStateError,
     metadataError,
+    result: activeResult,
   });
 
   useEffect(() => {
@@ -126,7 +95,8 @@ export function App() {
 
   const feedCreation = metadata?.instance.feed_creation ?? DEFAULT_FEED_CREATION;
   const featuredFeeds = metadata?.instance.featured_feeds ?? [];
-  const submitDisabled = isConverting || !feedCreation.enabled || isTokenRoute;
+  const submitDisabled =
+    isConverting || !feedCreation.enabled || viewModel.kind === 'token_prompt';
 
   const setFeedField = (key: 'url', value: string) => {
     setFeedFormData((previous) => {
@@ -262,11 +232,10 @@ export function App() {
         <p>Reading feed-generation capabilities.</p>
       </Notice>
     );
-  } else if (activeResult) {
+  } else if (viewModel.kind === 'result') {
     bodyContent = (
       <ResultDisplay
-        result={activeResult}
-        workflowState={workflowState}
+        viewModel={viewModel}
         onCreateAnother={handleCreateAnother}
         onRetryPreview={retryPreviewFetch}
       />
@@ -275,18 +244,13 @@ export function App() {
     bodyContent = (
       <CreateFeedPanel
         focusComposerKey={focusCreateComposerKey}
-        workflowState={workflowState}
+        viewModel={viewModel}
         feedFormData={feedFormData}
         feedFieldErrors={feedFieldErrors}
-        conversionError={conversionError}
-        errorKind={conversionError?.kind}
-        isConverting={isConverting}
         submitDisabled={submitDisabled}
         feedCreationEnabled={feedCreation.enabled}
         featuredFeeds={featuredFeeds}
         tokenDraft={tokenDraft}
-        tokenError={tokenError}
-        showTokenPrompt={isTokenRoute}
         onFeedSubmit={handleFeedSubmit}
         onFeedFieldChange={setFeedField}
         onTokenDraftChange={(value) => {

--- a/frontend/src/components/AppPanels.tsx
+++ b/frontend/src/components/AppPanels.tsx
@@ -50,7 +50,7 @@ export function CreateFeedPanel({
 }: CreateFeedPanelProperties) {
   const urlInputReference = useRef<HTMLInputElement>(undefined as never);
   const tokenInputReference = useRef<HTMLInputElement>(undefined as never);
-  const showTokenPrompt = viewModel.kind === 'token_prompt';
+  const isTokenPrompt = viewModel.kind === 'token_prompt';
   const isConverting = viewModel.kind === 'submitting';
   const conversionError =
     viewModel.kind === 'error' || viewModel.kind === 'token_prompt' ? viewModel.error : undefined;
@@ -79,14 +79,14 @@ export function CreateFeedPanel({
   }, [focusComposerKey]);
 
   useLayoutEffect(() => {
-    if (!showTokenPrompt || !tokenInputReference.current || globalThis.window === undefined) return;
+    if (!isTokenPrompt || !tokenInputReference.current || globalThis.window === undefined) return;
 
     const focusHandle = requestAnimationFrame(() => {
       tokenInputReference.current?.focus();
     });
 
     return () => cancelAnimationFrame(focusHandle);
-  }, [showTokenPrompt]);
+  }, [isTokenPrompt]);
 
   return (
     <form
@@ -95,7 +95,7 @@ export function CreateFeedPanel({
       data-state={viewModel.kind}
       data-error-kind={errorKind}
     >
-      <div class={`field-stack field-stack--dense${showTokenPrompt ? ' field-stack--inactive' : ''}`}>
+      <div class={`field-stack field-stack--dense${isTokenPrompt ? ' field-stack--inactive' : ''}`}>
         <DominantField
           className="layout-rail-reading"
           id="url"
@@ -151,7 +151,7 @@ export function CreateFeedPanel({
         )}
       </div>
 
-      {showTokenPrompt && (
+      {isTokenPrompt && (
         <div class="token-gate layout-rail-reading" role="group" aria-label="Access token">
           <div class="token-gate__copy">
             <h2>Enter access token</h2>

--- a/frontend/src/components/AppPanels.tsx
+++ b/frontend/src/components/AppPanels.tsx
@@ -2,7 +2,7 @@ import { useLayoutEffect, useRef } from 'preact/hooks';
 import { Bookmarklet } from './Bookmarklet';
 import { DominantField } from './DominantField';
 import { Notice } from './Notice';
-import type { FeedCreationError } from '../api/contracts';
+import type { AppViewModel } from '../appViewModel';
 
 export interface FeedFormData {
   url: string;
@@ -13,24 +13,17 @@ export interface FeedFieldErrors {
   form: string;
 }
 
-export type WorkflowState = 'create' | 'submitting' | 'token_prompt' | 'result' | 'error';
-
-export type WorkflowErrorKind = FeedCreationError['kind'];
+type CreatePanelViewModel = Exclude<AppViewModel, { kind: 'result' }>;
 
 interface CreateFeedPanelProperties {
   focusComposerKey: number;
-  workflowState: WorkflowState;
+  viewModel: CreatePanelViewModel;
   feedFormData: FeedFormData;
   feedFieldErrors: FeedFieldErrors;
-  conversionError?: FeedCreationError;
-  errorKind?: WorkflowErrorKind;
-  isConverting: boolean;
   submitDisabled: boolean;
   feedCreationEnabled: boolean;
   featuredFeeds: Array<{ path: string; title: string; description: string }>;
   tokenDraft: string;
-  tokenError: string;
-  showTokenPrompt: boolean;
   onFeedSubmit: (event: Event) => void;
   onFeedFieldChange: (key: 'url', value: string) => void;
   onTokenDraftChange: (value: string) => void;
@@ -41,18 +34,13 @@ interface CreateFeedPanelProperties {
 
 export function CreateFeedPanel({
   focusComposerKey,
-  workflowState,
+  viewModel,
   feedFormData,
   feedFieldErrors,
-  conversionError,
-  errorKind,
-  isConverting,
   submitDisabled,
   feedCreationEnabled,
   featuredFeeds,
   tokenDraft,
-  tokenError,
-  showTokenPrompt,
   onFeedSubmit,
   onFeedFieldChange,
   onTokenDraftChange,
@@ -62,7 +50,16 @@ export function CreateFeedPanel({
 }: CreateFeedPanelProperties) {
   const urlInputReference = useRef<HTMLInputElement>(undefined as never);
   const tokenInputReference = useRef<HTMLInputElement>(undefined as never);
-  const failureMessage = conversionError?.message || feedFieldErrors.form;
+  const showTokenPrompt = viewModel.kind === 'token_prompt';
+  const isConverting = viewModel.kind === 'submitting';
+  const conversionError =
+    viewModel.kind === 'error' || viewModel.kind === 'token_prompt' ? viewModel.error : undefined;
+  const tokenError = viewModel.kind === 'token_prompt' ? viewModel.tokenError : '';
+  const errorKind = viewModel.kind === 'error' ? viewModel.errorKind : conversionError?.kind;
+  const failureMessage =
+    (viewModel.kind === 'error' ? viewModel.message : undefined) ||
+    conversionError?.message ||
+    feedFieldErrors.form;
   const isShowRetryButton = Boolean(
     conversionError && conversionError.nextAction === 'retry' && conversionError.retryAction !== 'none'
   );
@@ -95,7 +92,7 @@ export function CreateFeedPanel({
     <form
       class="form-shell form-shell--minimal"
       onSubmit={onFeedSubmit}
-      data-state={workflowState}
+      data-state={viewModel.kind}
       data-error-kind={errorKind}
     >
       <div class={`field-stack field-stack--dense${showTokenPrompt ? ' field-stack--inactive' : ''}`}>

--- a/frontend/src/components/ResultDisplay.tsx
+++ b/frontend/src/components/ResultDisplay.tsx
@@ -1,12 +1,10 @@
 import type { ComponentChildren } from 'preact';
 import { useEffect, useRef, useState } from 'preact/hooks';
-import type { CreatedFeedResult } from '../api/contracts';
-import type { WorkflowState } from './AppPanels';
+import type { AppViewModel } from '../appViewModel';
 import { DominantField } from './DominantField';
 
 interface ResultDisplayProperties {
-  result: CreatedFeedResult;
-  workflowState: WorkflowState;
+  viewModel: Extract<AppViewModel, { kind: 'result' }>;
   onCreateAnother: () => void;
   onRetryPreview: () => void;
 }
@@ -30,14 +28,13 @@ function PreviewSection({ ariaLabel, intro, children }: PreviewSectionProperties
 }
 
 export function ResultDisplay({
-  result,
-  workflowState,
+  viewModel,
   onCreateAnother,
   onRetryPreview,
 }: ResultDisplayProperties) {
   const [copied, setCopied] = useState(false);
   const copyResetReference = useRef<ReturnType<typeof globalThis.setTimeout> | undefined>(undefined);
-  const { feed, preview, workflowState: previewWorkflowState, warnings } = result;
+  const { feed, preview, warnings } = viewModel;
 
   const fullUrl = feed.public_url.startsWith('http')
     ? feed.public_url
@@ -46,19 +43,19 @@ export function ResultDisplay({
     ? feed.json_public_url
     : `${location.origin}${feed.json_public_url}`;
   const subscribeUrl = /^https?:\/\//i.test(fullUrl) ? `feed:${fullUrl}` : undefined;
-  const canUseFeed = previewWorkflowState !== 'preview_loading';
+  const canUseFeed = preview.status !== 'preview_loading';
   const canManuallyRetryPreview =
-    previewWorkflowState === 'preview_failed' && warnings.some((warning) => warning.retryable);
+    preview.status === 'preview_failed' && warnings.some((warning) => warning.retryable);
   const statusTitle = {
     created: 'Feed created',
     preview_loading: 'Checking preview',
     preview_ready: 'Feed ready',
     preview_failed: 'Feed link created',
-  }[previewWorkflowState];
+  }[preview.status];
   const previewMessage = warnings[0]?.message ?? '';
   const hasPreviewItems = preview.items.length > 0;
   const isShowPreviewError =
-    previewWorkflowState === 'preview_failed' && !preview.isLoading && !hasPreviewItems && !!previewMessage;
+    preview.status === 'preview_failed' && !preview.isLoading && !hasPreviewItems && !!previewMessage;
 
   useEffect(() => {
     return () => {
@@ -78,7 +75,7 @@ export function ResultDisplay({
   };
 
   return (
-    <section class="result-shell layout-stack" aria-live="polite" data-state={workflowState}>
+    <section class="result-shell layout-stack" aria-live="polite" data-state={viewModel.kind}>
       <header class="result-header layout-rail-reading layout-stack layout-stack--tight">
         <p class="ui-eyebrow">{statusTitle}</p>
         <h1 class="result-title ui-display-title">{feed.name}</h1>

--- a/frontend/src/components/ResultDisplay.tsx
+++ b/frontend/src/components/ResultDisplay.tsx
@@ -27,11 +27,7 @@ function PreviewSection({ ariaLabel, intro, children }: PreviewSectionProperties
   );
 }
 
-export function ResultDisplay({
-  viewModel,
-  onCreateAnother,
-  onRetryPreview,
-}: ResultDisplayProperties) {
+export function ResultDisplay({ viewModel, onCreateAnother, onRetryPreview }: ResultDisplayProperties) {
   const [copied, setCopied] = useState(false);
   const copyResetReference = useRef<ReturnType<typeof globalThis.setTimeout> | undefined>(undefined);
   const { feed, preview, warnings } = viewModel;

--- a/frontend/src/feeds/feedCreationError.ts
+++ b/frontend/src/feeds/feedCreationError.ts
@@ -1,0 +1,206 @@
+import type { FeedCreationError, FeedNextAction, FeedRetryAction } from '../api/contracts';
+import { isTransientHttpStatus, normalizeBoolean, normalizeString } from './shared';
+
+export interface RawErrorEnvelope {
+  kind?: unknown;
+  code?: unknown;
+  retryable?: unknown;
+  next_action?: unknown;
+  retry_action?: unknown;
+  message?: unknown;
+}
+
+export interface RawApiResponse {
+  success?: unknown;
+  data?: unknown;
+  error?: unknown;
+}
+
+export function normalizeFeedCreationError(error: unknown): FeedCreationError {
+  if (isFeedCreationError(error)) return error;
+
+  if (error instanceof Error) {
+    return buildStructuredError(
+      'network',
+      'NETWORK_ERROR',
+      true,
+      'retry',
+      'primary',
+      error.message || 'Unable to reach the server.'
+    );
+  }
+
+  return buildStructuredError(
+    'server',
+    'UNKNOWN_ERROR',
+    true,
+    'retry',
+    'primary',
+    'Unable to complete feed creation.'
+  );
+}
+
+export function normalizeFeedCreationErrorFromResponse(
+  status: number,
+  errorPayload: unknown,
+  payload?: RawApiResponse
+): FeedCreationError {
+  const envelope = resolveErrorEnvelope(errorPayload, payload);
+
+  const kind = normalizeErrorKind(envelope?.kind, status);
+  const isRetryable = normalizeBoolean(envelope?.retryable, defaultRetryableFromStatus(status, kind));
+  const nextAction = normalizeNextAction(envelope?.next_action, kind, isRetryable);
+  const retryAction = normalizeRetryAction(envelope?.retry_action, nextAction, isRetryable);
+  const code = normalizeString(envelope?.code) || fallbackErrorCode(status, kind);
+  const message = normalizeString(envelope?.message) || fallbackErrorMessage(status, kind, nextAction);
+
+  return buildStructuredError(kind, code, isRetryable, nextAction, retryAction, message, status);
+}
+
+export function buildStructuredError(
+  kind: FeedCreationError['kind'],
+  code: string,
+  // eslint-disable-next-line unicorn/consistent-boolean-name
+  retryable: boolean,
+  nextAction: FeedNextAction,
+  retryAction: FeedRetryAction,
+  message: string,
+  status?: number
+): FeedCreationError {
+  return {
+    kind,
+    code,
+    retryable,
+    nextAction,
+    retryAction,
+    message,
+    ...(typeof status === 'number' && { status }),
+  };
+}
+
+export function buildLocalError(
+  message: string,
+  kind: FeedCreationError['kind'],
+  nextAction: FeedNextAction
+): FeedCreationError {
+  const isRetryable = nextAction === 'retry';
+  return buildStructuredError(
+    kind,
+    localErrorCode(kind, nextAction),
+    isRetryable,
+    nextAction,
+    isRetryable ? 'primary' : 'none',
+    message
+  );
+}
+
+function resolveErrorEnvelope(errorPayload: unknown, payload?: RawApiResponse): RawErrorEnvelope | undefined {
+  if (isErrorEnvelope(errorPayload)) return errorPayload;
+  if (isErrorEnvelope(payload?.error)) return payload.error;
+  if (isErrorEnvelope(payload)) return payload;
+  return undefined;
+}
+
+function normalizeNextAction(
+  value: unknown,
+  kind: FeedCreationError['kind'],
+  // eslint-disable-next-line unicorn/consistent-boolean-name
+  retryable: boolean
+): FeedNextAction {
+  if ((['enter_token', 'correct_input', 'retry', 'wait', 'none'] as unknown[]).includes(value)) {
+    return value as FeedNextAction;
+  }
+
+  if (kind === 'auth') return 'enter_token';
+  if (kind === 'input') return 'correct_input';
+  if (retryable) return 'retry';
+  return 'none';
+}
+
+function normalizeRetryAction(
+  value: unknown,
+  nextAction: FeedNextAction,
+  // eslint-disable-next-line unicorn/consistent-boolean-name
+  retryable: boolean
+): FeedRetryAction {
+  if ((['alternate', 'primary', 'none'] as unknown[]).includes(value)) {
+    return value as FeedRetryAction;
+  }
+
+  if (!retryable || nextAction !== 'retry') return 'none';
+  return 'primary';
+}
+
+function normalizeErrorKind(value: unknown, status: number): FeedCreationError['kind'] {
+  if ((['auth', 'input', 'network', 'server'] as unknown[]).includes(value))
+    return value as FeedCreationError['kind'];
+
+  if (status === 401 || status === 403) return 'auth';
+  if ([400, 404, 422].includes(status)) return 'input';
+  if (isTransientHttpStatus(status)) return 'network';
+  return 'server';
+}
+
+// eslint-disable-next-line unicorn/consistent-boolean-name
+function defaultRetryableFromStatus(status: number, kind: FeedCreationError['kind']): boolean {
+  if (kind === 'auth' || kind === 'input') return false;
+  if (kind === 'network') return true;
+  return isTransientHttpStatus(status) || status >= 500;
+}
+
+function fallbackErrorCode(status: number, kind: FeedCreationError['kind']): string {
+  if (status === 401) return 'AUTH_REQUIRED';
+  if (status === 403) return 'AUTH_FORBIDDEN';
+  if (status === 400) return 'INVALID_INPUT';
+  if (status === 404) return 'NOT_FOUND';
+  if (status === 422) return 'UNPROCESSABLE_INPUT';
+  if (isTransientHttpStatus(status)) return 'TRANSIENT_ERROR';
+  if (status >= 500) return 'SERVER_ERROR';
+  return `${kind.toUpperCase()}_ERROR`;
+}
+
+function fallbackErrorMessage(
+  status: number,
+  kind: FeedCreationError['kind'],
+  nextAction: FeedNextAction
+): string {
+  if (kind === 'auth') return 'Access token is required.';
+  if (kind === 'input') return 'Check the URL and try again.';
+  if (nextAction === 'wait') return 'The server is still processing the request.';
+  if (isTransientHttpStatus(status) || kind === 'network') return 'Unable to reach the server. Try again.';
+  return 'Unable to complete feed creation.';
+}
+
+function localErrorCode(kind: FeedCreationError['kind'], nextAction: FeedNextAction): string {
+  if (kind === 'auth') return 'AUTH_REQUIRED';
+  if (kind === 'input' && nextAction === 'correct_input') return 'INVALID_INPUT';
+  return 'LOCAL_VALIDATION_ERROR';
+}
+
+function isFeedCreationError(value: unknown): value is FeedCreationError {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as Partial<FeedCreationError>;
+  return (
+    (['auth', 'input', 'network', 'server'] as unknown[]).includes(candidate.kind) &&
+    typeof candidate.code === 'string' &&
+    typeof candidate.retryable === 'boolean' &&
+    typeof candidate.nextAction === 'string' &&
+    typeof candidate.retryAction === 'string' &&
+    typeof candidate.message === 'string'
+  );
+}
+
+function isErrorEnvelope(value: unknown): value is RawErrorEnvelope {
+  if (!value || typeof value !== 'object') return false;
+
+  const candidate = value as RawErrorEnvelope;
+  return (
+    candidate.kind !== undefined ||
+    candidate.code !== undefined ||
+    candidate.retryable !== undefined ||
+    candidate.next_action !== undefined ||
+    candidate.retry_action !== undefined ||
+    candidate.message !== undefined
+  );
+}

--- a/frontend/src/feeds/feedsApi.ts
+++ b/frontend/src/feeds/feedsApi.ts
@@ -1,0 +1,95 @@
+import type { FeedRecord } from '../api/contracts';
+import {
+  buildStructuredError,
+  normalizeFeedCreationErrorFromResponse,
+  type RawApiResponse,
+} from './feedCreationError';
+import { normalizeString, readJsonResponse } from './shared';
+
+interface RawFeedRecord {
+  id?: unknown;
+  name?: unknown;
+  url?: unknown;
+  feed_token?: unknown;
+  public_url?: unknown;
+  json_public_url?: unknown;
+  created_at?: unknown;
+  updated_at?: unknown;
+}
+
+interface RawFeedPayload {
+  feed?: RawFeedRecord;
+}
+
+interface RawFeedApiResponse extends RawApiResponse {
+  data?: RawFeedPayload;
+}
+
+export async function requestFeedCreation(url: string, token: string): Promise<FeedRecord> {
+  const response = await fetch(resolveApiUrl('feeds'), {
+    method: 'POST',
+    headers: buildCreateHeaders(token),
+    body: JSON.stringify({ url }),
+  });
+
+  const payload = await readJsonResponse<RawFeedApiResponse>(response);
+
+  if (!response.ok) {
+    throw normalizeFeedCreationErrorFromResponse(response.status, payload?.error, payload);
+  }
+
+  const feed = normalizeFeedRecord(payload?.data?.feed);
+  if (!feed) {
+    throw buildStructuredError(
+      'server',
+      'INVALID_RESPONSE',
+      true,
+      'retry',
+      'primary',
+      'Unable to start feed generation.',
+      response.status
+    );
+  }
+
+  return feed;
+}
+
+export function normalizeFeedRecord(raw?: RawFeedRecord): FeedRecord | undefined {
+  if (!raw) return undefined;
+
+  const feedToken = normalizeString(raw.feed_token);
+  const publicUrl = normalizeString(raw.public_url);
+  const jsonPublicUrl = normalizeString(raw.json_public_url);
+  const url = normalizeString(raw.url);
+
+  if (!feedToken || !publicUrl || !jsonPublicUrl || !url) return undefined;
+
+  return {
+    id: normalizeString(raw.id) || feedToken,
+    name: normalizeString(raw.name) || url,
+    url,
+    feed_token: feedToken,
+    public_url: publicUrl,
+    json_public_url: jsonPublicUrl,
+    created_at: normalizeString(raw.created_at) || new Date().toISOString(),
+    updated_at: normalizeString(raw.updated_at) || new Date().toISOString(),
+  };
+}
+
+export function resolveApiUrl(path: string): string {
+  return `/api/v1/${path.replace(/^\/+/, '')}`;
+}
+
+export function buildCreateHeaders(token: string): HeadersInit {
+  const normalizedToken = token.trim();
+  const headers: Record<string, string> = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  };
+
+  if (normalizedToken) {
+    headers.Authorization = `Bearer ${normalizedToken}`;
+  }
+
+  return headers;
+}

--- a/frontend/src/feeds/previewHydration.ts
+++ b/frontend/src/feeds/previewHydration.ts
@@ -73,10 +73,7 @@ export async function loadPreviewItemsWithRetry(
   );
 }
 
-export async function loadPreviewItems(
-  previewUrl: string,
-  signal?: AbortSignal
-): Promise<PreviewLoadResult> {
+export async function loadPreviewItems(previewUrl: string, signal?: AbortSignal): Promise<PreviewLoadResult> {
   let response: Response;
 
   try {

--- a/frontend/src/feeds/previewHydration.ts
+++ b/frontend/src/feeds/previewHydration.ts
@@ -1,0 +1,187 @@
+import type {
+  CreatedFeedResult,
+  FeedPreviewItem,
+  FeedPreviewStatus,
+  FeedPreviewWarning,
+  FeedNextAction,
+  FeedRecord,
+} from '../api/contracts';
+import { isAbortError, isTransientHttpStatus, normalizeString, resolveFetchUrl, wait } from './shared';
+
+export const PREVIEW_RETRY_DELAYS_MS = [260, 620, 1180, 1800] as const;
+export const PREVIEW_UNAVAILABLE_MESSAGE = 'Preview unavailable right now.';
+export const PREVIEW_DEGRADED_MESSAGE = 'Preview content is partially degraded right now.';
+
+export interface PreviewLoadResult {
+  items: FeedPreviewItem[];
+  warnings: FeedPreviewWarning[];
+  status: Extract<FeedPreviewStatus, 'preview_ready' | 'preview_failed'>;
+}
+
+interface JsonFeedResponse {
+  items?: unknown[];
+}
+
+export function buildCreatedFeedResult(feed: FeedRecord): CreatedFeedResult {
+  return {
+    feed,
+    preview: {
+      status: 'created',
+      items: [],
+      isLoading: false,
+    },
+    warnings: [],
+  };
+}
+
+export function buildPreviewLoadingResult(feed: FeedRecord): CreatedFeedResult {
+  return {
+    feed,
+    preview: {
+      status: 'preview_loading',
+      items: [],
+      isLoading: true,
+    },
+    warnings: [],
+  };
+}
+
+export async function loadPreviewItemsWithRetry(
+  previewUrl: string,
+  signal?: AbortSignal
+): Promise<PreviewLoadResult> {
+  const delays = [0, ...PREVIEW_RETRY_DELAYS_MS];
+  let latestRetryableFailure: PreviewLoadResult | undefined;
+
+  for (const [index, delayMs] of delays.entries()) {
+    if (delayMs > 0) await wait(delayMs, signal);
+
+    const result = await loadPreviewItems(previewUrl, signal);
+    if (result.status === 'preview_ready') return result;
+    if (result.warnings.every((warning) => !warning.retryable)) return result;
+
+    latestRetryableFailure = result;
+    if (index === delays.length - 1) return result;
+  }
+
+  return (
+    latestRetryableFailure ?? {
+      items: [],
+      warnings: [buildPreviewWarning('PREVIEW_FAILED', PREVIEW_UNAVAILABLE_MESSAGE, true, 'retry')],
+      status: 'preview_failed',
+    }
+  );
+}
+
+export async function loadPreviewItems(
+  previewUrl: string,
+  signal?: AbortSignal
+): Promise<PreviewLoadResult> {
+  let response: Response;
+
+  try {
+    response = await fetch(resolveFetchUrl(previewUrl), {
+      headers: { Accept: 'application/feed+json' },
+      signal,
+    });
+  } catch (error) {
+    if (isAbortError(error)) throw error;
+
+    return {
+      items: [],
+      warnings: [buildPreviewWarning('PREVIEW_NETWORK_ERROR', PREVIEW_UNAVAILABLE_MESSAGE, true, 'retry')],
+      status: 'preview_failed',
+    };
+  }
+
+  if (!response.ok) {
+    return {
+      items: [],
+      warnings: [
+        buildPreviewWarning(
+          `PREVIEW_HTTP_${response.status}`,
+          isTransientHttpStatus(response.status) ? PREVIEW_DEGRADED_MESSAGE : PREVIEW_UNAVAILABLE_MESSAGE,
+          isTransientHttpStatus(response.status),
+          isTransientHttpStatus(response.status) ? 'retry' : 'wait'
+        ),
+      ],
+      status: 'preview_failed',
+    };
+  }
+
+  try {
+    const payload = (await response.json()) as JsonFeedResponse;
+    return {
+      items: normalizePreviewItems(payload.items),
+      warnings: [],
+      status: 'preview_ready',
+    };
+  } catch {
+    return {
+      items: [],
+      warnings: [buildPreviewWarning('PREVIEW_INVALID_JSON', PREVIEW_UNAVAILABLE_MESSAGE, false, 'wait')],
+      status: 'preview_failed',
+    };
+  }
+}
+
+export function buildPreviewWarning(
+  code: string,
+  message: string,
+  // eslint-disable-next-line unicorn/consistent-boolean-name
+  retryable: boolean,
+  nextAction: FeedNextAction
+): FeedPreviewWarning {
+  return { code, message, retryable, nextAction };
+}
+
+export function normalizePreviewItems(items: unknown[] | undefined): FeedPreviewItem[] {
+  if (!Array.isArray(items)) return [];
+
+  return items
+    .map((item) => normalizePreviewItem(item))
+    .filter((item): item is FeedPreviewItem => item !== undefined)
+    .slice(0, 5);
+}
+
+function normalizePreviewItem(value: unknown): FeedPreviewItem | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+
+  const candidate = value as {
+    title?: unknown;
+    excerpt?: unknown;
+    description?: unknown;
+    content_text?: unknown;
+    contentText?: unknown;
+    published_label?: unknown;
+    publishedLabel?: unknown;
+    date_published?: unknown;
+    datePublished?: unknown;
+    date_modified?: unknown;
+    dateModified?: unknown;
+    url?: unknown;
+  };
+
+  const title = normalizeString(candidate.title);
+  if (!title) return undefined;
+
+  const url = normalizeString(candidate.url);
+
+  return {
+    title,
+    excerpt:
+      normalizeString(
+        candidate.excerpt ?? candidate.description ?? candidate.content_text ?? candidate.contentText
+      ) || '',
+    publishedLabel:
+      normalizeString(
+        candidate.published_label ??
+          candidate.publishedLabel ??
+          candidate.date_published ??
+          candidate.datePublished ??
+          candidate.date_modified ??
+          candidate.dateModified
+      ) || '',
+    ...(url && { url }),
+  };
+}

--- a/frontend/src/feeds/shared.ts
+++ b/frontend/src/feeds/shared.ts
@@ -1,0 +1,62 @@
+export function normalizeString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+// eslint-disable-next-line unicorn/consistent-boolean-name
+export function normalizeBoolean(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+export function isTransientHttpStatus(status: number): boolean {
+  return [408, 409, 425, 429, 500, 502, 503, 504].includes(status);
+}
+
+export function isAbortError(error: unknown): boolean {
+  return (
+    (error instanceof DOMException && error.name === 'AbortError') ||
+    (error instanceof Error && error.name === 'AbortError')
+  );
+}
+
+export async function wait(delayMs: number, signal?: AbortSignal): Promise<void> {
+  if (delayMs <= 0) return;
+
+  await new Promise<void>((resolve, reject) => {
+    const timeoutHandle = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, delayMs);
+
+    const onAbort = () => {
+      clearTimeout(timeoutHandle);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+
+    if (signal) {
+      if (signal.aborted) {
+        clearTimeout(timeoutHandle);
+        reject(new DOMException('Aborted', 'AbortError'));
+        return;
+      }
+
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+  });
+}
+
+export function resolveFetchUrl(url: string): string {
+  if (/^https?:\/\//i.test(url)) return url;
+  const origin = globalThis.location?.origin ?? 'http://localhost';
+  return new URL(url, origin).href;
+}
+
+export async function readJsonResponse<T>(response: Response): Promise<T | undefined> {
+  const bodyText = await response.text();
+  if (!bodyText.trim()) return undefined;
+
+  try {
+    return JSON.parse(bodyText) as T;
+  } catch {
+    return undefined;
+  }
+}

--- a/frontend/src/hooks/useFeedConversion.ts
+++ b/frontend/src/hooks/useFeedConversion.ts
@@ -1,65 +1,25 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
-import type {
-  CreatedFeedResult,
-  FeedCreationError,
-  FeedNextAction,
-  FeedPreviewItem,
-  FeedPreviewWarning,
-  FeedRecord,
-  FeedRetryAction,
-  FeedWorkflowState,
-} from '../api/contracts';
-import { normalizeUserUrl } from '../utils/url';
+import type { CreatedFeedResult, FeedCreationError } from '../api/contracts';
+import {
+  buildLocalError,
+  normalizeFeedCreationError,
+} from '../feeds/feedCreationError';
+import { requestFeedCreation } from '../feeds/feedsApi';
+import {
+  buildCreatedFeedResult,
+  buildPreviewLoadingResult,
+  buildPreviewWarning,
+  loadPreviewItemsWithRetry,
+  PREVIEW_UNAVAILABLE_MESSAGE,
+} from '../feeds/previewHydration';
+import { isAbortError } from '../feeds/shared';
+import { isNormalizedHttpUrl, normalizeUserUrl } from '../utils/url';
 
 interface ConversionState {
   isConverting: boolean;
   result?: CreatedFeedResult;
   error?: FeedCreationError;
 }
-
-interface RawFeedRecord {
-  id?: unknown;
-  name?: unknown;
-  url?: unknown;
-  feed_token?: unknown;
-  public_url?: unknown;
-  json_public_url?: unknown;
-  created_at?: unknown;
-  updated_at?: unknown;
-}
-
-interface RawFeedPayload {
-  feed?: RawFeedRecord;
-}
-
-interface RawApiResponse {
-  success?: unknown;
-  data?: RawFeedPayload;
-  error?: unknown;
-}
-
-interface RawErrorEnvelope {
-  kind?: unknown;
-  code?: unknown;
-  retryable?: unknown;
-  next_action?: unknown;
-  retry_action?: unknown;
-  message?: unknown;
-}
-
-interface JsonFeedResponse {
-  items?: unknown[];
-}
-
-interface PreviewLoadResult {
-  items: FeedPreviewItem[];
-  warnings: FeedPreviewWarning[];
-  workflowState: Extract<FeedWorkflowState, 'preview_ready' | 'preview_failed'>;
-}
-
-const PREVIEW_RETRY_DELAYS_MS = [260, 620, 1180, 1800] as const;
-const PREVIEW_UNAVAILABLE_MESSAGE = 'Preview unavailable right now.';
-const PREVIEW_DEGRADED_MESSAGE = 'Preview content is partially degraded right now.';
 
 export function useFeedConversion() {
   const requestIdReference = useRef(0);
@@ -83,7 +43,7 @@ export function useFeedConversion() {
     const normalizedUrl = normalizeUserUrl(url);
 
     if (!normalizedUrl) throw buildLocalError('Source URL is required.', 'input', 'correct_input');
-    if (!isValidHttpUrl(normalizedUrl))
+    if (!isNormalizedHttpUrl(normalizedUrl))
       throw buildLocalError('Invalid URL format.', 'input', 'correct_input');
 
     const requestId = requestIdReference.current + 1;
@@ -94,7 +54,7 @@ export function useFeedConversion() {
     try {
       const feed = await requestFeedCreation(normalizedUrl, token);
       const result = buildCreatedFeedResult(feed);
-      publishResult(result, requestId, setState, requestIdReference);
+      commitResult(result, requestId, setState, requestIdReference);
       void hydrateFeedPreview(feed, requestId, setState, requestIdReference, previewAbortControllerReference);
       return result;
     } catch (error) {
@@ -143,37 +103,8 @@ export function useFeedConversion() {
   };
 }
 
-async function requestFeedCreation(url: string, token: string): Promise<FeedRecord> {
-  const response = await fetch(resolveApiUrl('feeds'), {
-    method: 'POST',
-    headers: buildCreateHeaders(token),
-    body: JSON.stringify({ url }),
-  });
-
-  const payload = await readJsonResponse<RawApiResponse>(response);
-
-  if (!response.ok) {
-    throw normalizeFeedCreationErrorFromResponse(response.status, payload?.error, payload);
-  }
-
-  const feed = normalizeFeedRecord(payload?.data?.feed);
-  if (!feed) {
-    throw buildStructuredError(
-      'server',
-      'INVALID_RESPONSE',
-      true,
-      'retry',
-      'primary',
-      'Unable to start feed generation.',
-      response.status
-    );
-  }
-
-  return feed;
-}
-
 async function hydrateFeedPreview(
-  feed: FeedRecord,
+  feed: CreatedFeedResult['feed'],
   requestId: number,
   setState: (value: ConversionState | ((previous: ConversionState) => ConversionState)) => void,
   requestIdReference: { current: number },
@@ -193,10 +124,10 @@ async function hydrateFeedPreview(
       {
         feed,
         preview: {
+          status: previewResult.status,
           items: previewResult.items,
           isLoading: false,
         },
-        workflowState: previewResult.workflowState,
         warnings: previewResult.warnings,
       },
       requestId,
@@ -210,10 +141,10 @@ async function hydrateFeedPreview(
       {
         feed,
         preview: {
+          status: 'preview_failed',
           items: [],
           isLoading: false,
         },
-        workflowState: 'preview_failed',
         warnings: [buildPreviewWarning('PREVIEW_FAILED', PREVIEW_UNAVAILABLE_MESSAGE, true, 'retry')],
       },
       requestId,
@@ -225,106 +156,6 @@ async function hydrateFeedPreview(
       previewAbortControllerReference.current = undefined;
     }
   }
-}
-
-async function loadPreviewItemsWithRetry(
-  previewUrl: string,
-  signal?: AbortSignal
-): Promise<PreviewLoadResult> {
-  const delays = [0, ...PREVIEW_RETRY_DELAYS_MS];
-  let latestRetryableFailure: PreviewLoadResult | undefined;
-
-  for (const [index, delayMs] of delays.entries()) {
-    if (delayMs > 0) await wait(delayMs, signal);
-
-    const result = await loadPreviewItems(previewUrl, signal);
-    if (result.workflowState === 'preview_ready') return result;
-    if (result.warnings.every((warning) => !warning.retryable)) return result;
-
-    latestRetryableFailure = result;
-    if (index === delays.length - 1) return result;
-  }
-
-  return (
-    latestRetryableFailure ?? {
-      items: [],
-      warnings: [buildPreviewWarning('PREVIEW_FAILED', PREVIEW_UNAVAILABLE_MESSAGE, true, 'retry')],
-      workflowState: 'preview_failed',
-    }
-  );
-}
-
-async function loadPreviewItems(previewUrl: string, signal?: AbortSignal): Promise<PreviewLoadResult> {
-  let response: Response;
-
-  try {
-    response = await fetch(resolveFetchUrl(previewUrl), {
-      headers: { Accept: 'application/feed+json' },
-      signal,
-    });
-  } catch (error) {
-    if (isAbortError(error)) throw error;
-
-    return {
-      items: [],
-      warnings: [buildPreviewWarning('PREVIEW_NETWORK_ERROR', PREVIEW_UNAVAILABLE_MESSAGE, true, 'retry')],
-      workflowState: 'preview_failed',
-    };
-  }
-
-  if (!response.ok) {
-    return {
-      items: [],
-      warnings: [
-        buildPreviewWarning(
-          `PREVIEW_HTTP_${response.status}`,
-          isTransientHttpStatus(response.status) ? PREVIEW_DEGRADED_MESSAGE : PREVIEW_UNAVAILABLE_MESSAGE,
-          isTransientHttpStatus(response.status),
-          isTransientHttpStatus(response.status) ? 'retry' : 'wait'
-        ),
-      ],
-      workflowState: 'preview_failed',
-    };
-  }
-
-  try {
-    const payload = (await response.json()) as JsonFeedResponse;
-    return {
-      items: normalizePreviewItems(payload.items),
-      warnings: [],
-      workflowState: 'preview_ready',
-    };
-  } catch {
-    return {
-      items: [],
-      warnings: [buildPreviewWarning('PREVIEW_INVALID_JSON', PREVIEW_UNAVAILABLE_MESSAGE, false, 'wait')],
-      workflowState: 'preview_failed',
-    };
-  }
-}
-
-function buildCreatedFeedResult(feed: FeedRecord): CreatedFeedResult {
-  return {
-    feed,
-    preview: {
-      items: [],
-      isLoading: false,
-    },
-    workflowState: 'created',
-    warnings: [],
-  };
-}
-
-function buildPreviewLoadingResult(feed: FeedRecord): CreatedFeedResult {
-  return {
-    feed,
-    preview: {
-      items: [],
-      isLoading: true,
-    },
-    workflowState: 'preview_loading',
-    warnings: [],
-  };
 }
 
 function commitResult(
@@ -347,15 +178,6 @@ function commitResult(
   });
 }
 
-function publishResult(
-  result: CreatedFeedResult,
-  requestId: number,
-  setState: (value: ConversionState | ((previous: ConversionState) => ConversionState)) => void,
-  requestIdReference: { current: number }
-) {
-  commitResult(result, requestId, setState, requestIdReference);
-}
-
 function failConversion(
   setState: (value: ConversionState | ((previous: ConversionState) => ConversionState)) => void,
   error: FeedCreationError
@@ -365,366 +187,4 @@ function failConversion(
     isConverting: false,
     error,
   }));
-}
-
-function normalizeFeedCreationError(error: unknown): FeedCreationError {
-  if (isFeedCreationError(error)) return error;
-
-  if (error instanceof Error) {
-    return buildStructuredError(
-      'network',
-      'NETWORK_ERROR',
-      true,
-      'retry',
-      'primary',
-      error.message || 'Unable to reach the server.'
-    );
-  }
-
-  return buildStructuredError(
-    'server',
-    'UNKNOWN_ERROR',
-    true,
-    'retry',
-    'primary',
-    'Unable to complete feed creation.'
-  );
-}
-
-function normalizeFeedCreationErrorFromResponse(
-  status: number,
-  errorPayload: unknown,
-  payload?: RawApiResponse
-): FeedCreationError {
-  const envelope = resolveErrorEnvelope(errorPayload, payload);
-
-  const kind = normalizeErrorKind(envelope?.kind, status);
-  const isRetryable = normalizeBoolean(envelope?.retryable, defaultRetryableFromStatus(status, kind));
-  const nextAction = normalizeNextAction(envelope?.next_action, kind, isRetryable);
-  const retryAction = normalizeRetryAction(envelope?.retry_action, nextAction, isRetryable);
-  const code = normalizeString(envelope?.code) || fallbackErrorCode(status, kind);
-  const message = normalizeString(envelope?.message) || fallbackErrorMessage(status, kind, nextAction);
-
-  return buildStructuredError(kind, code, isRetryable, nextAction, retryAction, message, status);
-}
-
-function resolveErrorEnvelope(errorPayload: unknown, payload?: RawApiResponse): RawErrorEnvelope | undefined {
-  if (isErrorEnvelope(errorPayload)) return errorPayload;
-  if (isErrorEnvelope(payload?.error)) return payload.error;
-  if (isErrorEnvelope(payload)) return payload;
-  return undefined;
-}
-
-function buildStructuredError(
-  kind: FeedCreationError['kind'],
-  code: string,
-  // eslint-disable-next-line unicorn/consistent-boolean-name
-  retryable: boolean,
-  nextAction: FeedNextAction,
-  retryAction: FeedRetryAction,
-  message: string,
-  status?: number
-): FeedCreationError {
-  return {
-    kind,
-    code,
-    retryable,
-    nextAction,
-    retryAction,
-    message,
-    ...(typeof status === 'number' && { status }),
-  };
-}
-
-function buildLocalError(
-  message: string,
-  kind: FeedCreationError['kind'],
-  nextAction: FeedNextAction
-): FeedCreationError {
-  const isRetryable = nextAction === 'retry';
-  return buildStructuredError(
-    kind,
-    localErrorCode(kind, nextAction),
-    isRetryable,
-    nextAction,
-    isRetryable ? 'primary' : 'none',
-    message
-  );
-}
-
-function buildPreviewWarning(
-  code: string,
-  message: string,
-  // eslint-disable-next-line unicorn/consistent-boolean-name
-  retryable: boolean,
-  nextAction: FeedNextAction
-): FeedPreviewWarning {
-  return { code, message, retryable, nextAction };
-}
-
-function normalizeFeedRecord(raw?: RawFeedRecord): FeedRecord | undefined {
-  if (!raw) return undefined;
-
-  const feedToken = normalizeString(raw.feed_token);
-  const publicUrl = normalizeString(raw.public_url);
-  const jsonPublicUrl = normalizeString(raw.json_public_url);
-  const url = normalizeString(raw.url);
-
-  if (!feedToken || !publicUrl || !jsonPublicUrl || !url) return undefined;
-
-  return {
-    id: normalizeString(raw.id) || feedToken,
-    name: normalizeString(raw.name) || url,
-    url,
-    feed_token: feedToken,
-    public_url: publicUrl,
-    json_public_url: jsonPublicUrl,
-    created_at: normalizeString(raw.created_at) || new Date().toISOString(),
-    updated_at: normalizeString(raw.updated_at) || new Date().toISOString(),
-  };
-}
-
-function normalizeNextAction(
-  value: unknown,
-  kind: FeedCreationError['kind'],
-  // eslint-disable-next-line unicorn/consistent-boolean-name
-  retryable: boolean
-): FeedNextAction {
-  if ((['enter_token', 'correct_input', 'retry', 'wait', 'none'] as unknown[]).includes(value)) {
-    return value as FeedNextAction;
-  }
-
-  if (kind === 'auth') return 'enter_token';
-  if (kind === 'input') return 'correct_input';
-  if (retryable) return 'retry';
-  return 'none';
-}
-
-function normalizeRetryAction(
-  value: unknown,
-  nextAction: FeedNextAction,
-  // eslint-disable-next-line unicorn/consistent-boolean-name
-  retryable: boolean
-): FeedRetryAction {
-  if ((['alternate', 'primary', 'none'] as unknown[]).includes(value)) {
-    return value as FeedRetryAction;
-  }
-
-  if (!retryable || nextAction !== 'retry') return 'none';
-  return 'primary';
-}
-
-function normalizeErrorKind(value: unknown, status: number): FeedCreationError['kind'] {
-  if ((['auth', 'input', 'network', 'server'] as unknown[]).includes(value))
-    return value as FeedCreationError['kind'];
-
-  if (status === 401 || status === 403) return 'auth';
-  if ([400, 404, 422].includes(status)) return 'input';
-  if (isTransientHttpStatus(status)) return 'network';
-  return 'server';
-}
-
-// eslint-disable-next-line unicorn/consistent-boolean-name
-function defaultRetryableFromStatus(status: number, kind: FeedCreationError['kind']): boolean {
-  if (kind === 'auth' || kind === 'input') return false;
-  if (kind === 'network') return true;
-  return isTransientHttpStatus(status) || status >= 500;
-}
-
-function fallbackErrorCode(status: number, kind: FeedCreationError['kind']): string {
-  if (status === 401) return 'AUTH_REQUIRED';
-  if (status === 403) return 'AUTH_FORBIDDEN';
-  if (status === 400) return 'INVALID_INPUT';
-  if (status === 404) return 'NOT_FOUND';
-  if (status === 422) return 'UNPROCESSABLE_INPUT';
-  if (isTransientHttpStatus(status)) return 'TRANSIENT_ERROR';
-  if (status >= 500) return 'SERVER_ERROR';
-  return `${kind.toUpperCase()}_ERROR`;
-}
-
-function fallbackErrorMessage(
-  status: number,
-  kind: FeedCreationError['kind'],
-  nextAction: FeedNextAction
-): string {
-  if (kind === 'auth') return 'Access token is required.';
-  if (kind === 'input') return 'Check the URL and try again.';
-  if (nextAction === 'wait') return 'The server is still processing the request.';
-  if (isTransientHttpStatus(status) || kind === 'network') return 'Unable to reach the server. Try again.';
-  return 'Unable to complete feed creation.';
-}
-
-function localErrorCode(kind: FeedCreationError['kind'], nextAction: FeedNextAction): string {
-  if (kind === 'auth') return 'AUTH_REQUIRED';
-  if (kind === 'input' && nextAction === 'correct_input') return 'INVALID_INPUT';
-  return 'LOCAL_VALIDATION_ERROR';
-}
-
-function isFeedCreationError(value: unknown): value is FeedCreationError {
-  if (!value || typeof value !== 'object') return false;
-
-  const candidate = value as Partial<FeedCreationError>;
-  return (
-    (['auth', 'input', 'network', 'server'] as unknown[]).includes(candidate.kind) &&
-    typeof candidate.code === 'string' &&
-    typeof candidate.retryable === 'boolean' &&
-    typeof candidate.nextAction === 'string' &&
-    typeof candidate.retryAction === 'string' &&
-    typeof candidate.message === 'string'
-  );
-}
-
-function isErrorEnvelope(value: unknown): value is RawErrorEnvelope {
-  if (!value || typeof value !== 'object') return false;
-
-  const candidate = value as RawErrorEnvelope;
-  return (
-    candidate.kind !== undefined ||
-    candidate.code !== undefined ||
-    candidate.retryable !== undefined ||
-    candidate.next_action !== undefined ||
-    candidate.retry_action !== undefined ||
-    candidate.message !== undefined
-  );
-}
-
-// eslint-disable-next-line unicorn/consistent-boolean-name
-function normalizeBoolean(value: unknown, fallback: boolean): boolean {
-  return typeof value === 'boolean' ? value : fallback;
-}
-
-function normalizeString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
-}
-
-async function readJsonResponse<T>(response: Response): Promise<T | undefined> {
-  const bodyText = await response.text();
-  if (!bodyText.trim()) return undefined;
-
-  try {
-    return JSON.parse(bodyText) as T;
-  } catch {
-    return undefined;
-  }
-}
-
-function resolveApiUrl(path: string): string {
-  return `/api/v1/${path.replace(/^\/+/, '')}`;
-}
-
-function resolveFetchUrl(url: string): string {
-  if (/^https?:\/\//i.test(url)) return url;
-  const origin = globalThis.location?.origin ?? 'http://localhost';
-  return new URL(url, origin).href;
-}
-
-function buildCreateHeaders(token: string): HeadersInit {
-  const normalizedToken = token.trim();
-  const headers: Record<string, string> = {
-    Accept: 'application/json',
-    'Content-Type': 'application/json',
-  };
-
-  if (normalizedToken) {
-    headers.Authorization = `Bearer ${normalizedToken}`;
-  }
-
-  return headers;
-}
-
-function isTransientHttpStatus(status: number): boolean {
-  return [408, 409, 425, 429, 500, 502, 503, 504].includes(status);
-}
-
-function isAbortError(error: unknown): boolean {
-  return (
-    (error instanceof DOMException && error.name === 'AbortError') ||
-    (error instanceof Error && error.name === 'AbortError')
-  );
-}
-
-function isValidHttpUrl(value: string): boolean {
-  try {
-    const parsedUrl = new URL(value);
-    return parsedUrl.protocol === 'http:' || parsedUrl.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
-async function wait(delayMs: number, signal?: AbortSignal): Promise<void> {
-  if (delayMs <= 0) return;
-
-  await new Promise<void>((resolve, reject) => {
-    const timeoutHandle = setTimeout(() => {
-      signal?.removeEventListener('abort', onAbort);
-      resolve();
-    }, delayMs);
-
-    const onAbort = () => {
-      clearTimeout(timeoutHandle);
-      reject(new DOMException('Aborted', 'AbortError'));
-    };
-
-    if (signal) {
-      if (signal.aborted) {
-        clearTimeout(timeoutHandle);
-        reject(new DOMException('Aborted', 'AbortError'));
-        return;
-      }
-
-      signal.addEventListener('abort', onAbort, { once: true });
-    }
-  });
-}
-
-function normalizePreviewItems(items: unknown[] | undefined): FeedPreviewItem[] {
-  if (!Array.isArray(items)) return [];
-
-  return items
-    .map((item) => normalizePreviewItem(item))
-    .filter((item): item is FeedPreviewItem => item !== undefined)
-    .slice(0, 5);
-}
-
-function normalizePreviewItem(value: unknown): FeedPreviewItem | undefined {
-  if (!value || typeof value !== 'object') return undefined;
-
-  const candidate = value as {
-    title?: unknown;
-    excerpt?: unknown;
-    description?: unknown;
-    content_text?: unknown;
-    contentText?: unknown;
-    published_label?: unknown;
-    publishedLabel?: unknown;
-    date_published?: unknown;
-    datePublished?: unknown;
-    date_modified?: unknown;
-    dateModified?: unknown;
-    url?: unknown;
-  };
-
-  const title = normalizeString(candidate.title);
-  if (!title) return undefined;
-
-  const url = normalizeString(candidate.url);
-
-  return {
-    title,
-    excerpt:
-      normalizeString(
-        candidate.excerpt ?? candidate.description ?? candidate.content_text ?? candidate.contentText
-      ) || '',
-    publishedLabel:
-      normalizeString(
-        candidate.published_label ??
-          candidate.publishedLabel ??
-          candidate.date_published ??
-          candidate.datePublished ??
-          candidate.date_modified ??
-          candidate.dateModified
-      ) || '',
-    ...(url && { url }),
-  };
 }

--- a/frontend/src/hooks/useFeedConversion.ts
+++ b/frontend/src/hooks/useFeedConversion.ts
@@ -1,9 +1,6 @@
 import { useEffect, useRef, useState } from 'preact/hooks';
 import type { CreatedFeedResult, FeedCreationError } from '../api/contracts';
-import {
-  buildLocalError,
-  normalizeFeedCreationError,
-} from '../feeds/feedCreationError';
+import { buildLocalError, normalizeFeedCreationError } from '../feeds/feedCreationError';
 import { requestFeedCreation } from '../feeds/feedsApi';
 import {
   buildCreatedFeedResult,

--- a/spec/html2rss/web/api/v1_spec.rb
+++ b/spec/html2rss/web/api/v1_spec.rb
@@ -85,13 +85,12 @@ RSpec.describe 'api/v1', openapi: { example_mode: :none }, type: :request do
   end
 
   def ghost_feed_token
-    Html2rss::Web::FeedToken
-      .create_with_validation(
-        username: 'ghost',
-        url: feed_url,
-        secret_key: ENV.fetch('HTML2RSS_SECRET_KEY')
-      )
-      .encode
+    token = Html2rss::Web::FeedToken::Signer.create(
+      username: 'ghost',
+      url: feed_url,
+      secret_key: ENV.fetch('HTML2RSS_SECRET_KEY')
+    )
+    Html2rss::Web::FeedToken::Codec.encode(token)
   end
 
   def valid_feed_token

--- a/spec/html2rss/web/app_integration_spec.rb
+++ b/spec/html2rss/web/app_integration_spec.rb
@@ -409,8 +409,8 @@ RSpec.describe Html2rss::Web::App, :aggregate_failures do # rubocop:disable RSpe
   # @return [Hash{String=>Object}]
   def extraction_empty_error_fields
     {
-      'code' => Html2rss::Web::ErrorResponder::EXTRACTION_EMPTY_CODE,
-      'message' => Html2rss::Web::ErrorResponder::EXTRACTION_EMPTY_MESSAGE,
+      'code' => Html2rss::Web::ErrorClassifier::EXTRACTION_EMPTY_CODE,
+      'message' => Html2rss::Web::ErrorClassifier::EXTRACTION_EMPTY_MESSAGE,
       'kind' => 'input',
       'retryable' => false,
       'next_action' => 'correct_input',

--- a/spec/html2rss/web/app_integration_spec.rb
+++ b/spec/html2rss/web/app_integration_spec.rb
@@ -243,6 +243,9 @@ RSpec.describe Html2rss::Web::App, :aggregate_failures do # rubocop:disable RSpe
       allow(Html2rss::Web::FeedToken::Signer)
         .to receive(:validate).with(raw_token, feed_url, anything)
         .and_return(escaped_token_payload)
+      allow(Html2rss::Web::FeedToken::Signer)
+        .to receive(:validate_decoded).with(escaped_token_payload, feed_url, anything)
+        .and_return(escaped_token_payload)
     end
 
     # @return [void]

--- a/spec/html2rss/web/app_integration_spec.rb
+++ b/spec/html2rss/web/app_integration_spec.rb
@@ -238,10 +238,10 @@ RSpec.describe Html2rss::Web::App, :aggregate_failures do # rubocop:disable RSpe
         strategy: 'faraday'
       )
 
-      allow(Html2rss::Web::FeedToken).to receive(:decode).with(raw_token).and_return(escaped_token_payload)
-      allow(Html2rss::Web::FeedToken).to receive(:decode).with(encoded_token).and_return(nil)
-      allow(Html2rss::Web::FeedToken)
-        .to receive(:validate_and_decode).with(raw_token, feed_url, anything)
+      allow(Html2rss::Web::FeedToken::Codec).to receive(:decode).with(raw_token).and_return(escaped_token_payload)
+      allow(Html2rss::Web::FeedToken::Codec).to receive(:decode).with(encoded_token).and_return(nil)
+      allow(Html2rss::Web::FeedToken::Signer)
+        .to receive(:validate).with(raw_token, feed_url, anything)
         .and_return(escaped_token_payload)
     end
 

--- a/spec/html2rss/web/error_classifier_spec.rb
+++ b/spec/html2rss/web/error_classifier_spec.rb
@@ -46,6 +46,9 @@ RSpec.describe Html2rss::Web::ErrorClassifier do
         code: 'EXTRACTION_EMPTY',
         kind: 'input',
         cacheable: true,
+        retryable: false,
+        next_action: 'correct_input',
+        retry_action: 'none',
         message: a_string_including('could not extract feed items')
       )
     end

--- a/spec/html2rss/web/error_classifier_spec.rb
+++ b/spec/html2rss/web/error_classifier_spec.rb
@@ -8,6 +8,17 @@ RSpec.describe Html2rss::Web::ErrorClassifier do
     stub_const('Html2rss::NoFeedItemsExtracted', Class.new(Html2rss::Error))
   end
 
+  def stub_no_feed_items_extracted_with_attempts
+    stub_const('Html2rss::NoFeedItemsExtracted', Class.new(Html2rss::Error) do
+      def initialize(attempts:)
+        @attempts = attempts
+        super('No feed items extracted after auto fallback')
+      end
+
+      attr_reader :attempts
+    end)
+  end
+
   describe '.classify' do
     it 'returns the extraction-empty decision for NoFeedItemsExtracted' do
       klass = stub_no_feed_items_extracted
@@ -27,25 +38,16 @@ RSpec.describe Html2rss::Web::ErrorClassifier do
     end
 
     it 'ignores attempts payload when mapping HTTP semantics' do
-      klass = stub_const('Html2rss::NoFeedItemsExtracted', Class.new(Html2rss::Error) do
-        def initialize(attempts:)
-          @attempts = attempts
-          super('No feed items extracted after auto fallback')
-        end
-
-        attr_reader :attempts
-      end)
+      klass = stub_no_feed_items_extracted_with_attempts
       error = klass.new(attempts: [{ strategy: :faraday, items_count: 0 }])
 
-      decision = described_class.classify(error)
-
-      expect(decision).to have_attributes(
+      expect(described_class.classify(error)).to have_attributes(
         status: 422,
         code: 'EXTRACTION_EMPTY',
         kind: 'input',
-        cacheable: true
+        cacheable: true,
+        message: a_string_including('could not extract feed items')
       )
-      expect(decision.message).to include('could not extract feed items')
     end
 
     it 'returns nil for unrelated errors' do

--- a/spec/html2rss/web/error_classifier_spec.rb
+++ b/spec/html2rss/web/error_classifier_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../../app'
+
+RSpec.describe Html2rss::Web::ErrorClassifier do
+  def stub_no_feed_items_extracted
+    stub_const('Html2rss::NoFeedItemsExtracted', Class.new(Html2rss::Error))
+  end
+
+  describe '.classify' do
+    it 'returns the extraction-empty decision for NoFeedItemsExtracted' do
+      klass = stub_no_feed_items_extracted
+
+      expect(described_class.classify(klass.new('empty'))).to eq(described_class::EXTRACTION_EMPTY)
+    end
+
+    it 'detects NoFeedItemsExtracted through Exception#cause' do
+      klass = stub_no_feed_items_extracted
+      root = klass.new('empty')
+      wrapped = StandardError.new('wrapped')
+      outer = StandardError.new('outer')
+      allow(outer).to receive(:cause).and_return(wrapped)
+      allow(wrapped).to receive(:cause).and_return(root)
+
+      expect(described_class.classify(outer)).to eq(described_class::EXTRACTION_EMPTY)
+    end
+
+    it 'ignores attempts payload when mapping HTTP semantics' do
+      klass = stub_const('Html2rss::NoFeedItemsExtracted', Class.new(Html2rss::Error) do
+        def initialize(attempts:)
+          @attempts = attempts
+          super('No feed items extracted after auto fallback')
+        end
+
+        attr_reader :attempts
+      end)
+      error = klass.new(attempts: [{ strategy: :faraday, items_count: 0 }])
+
+      decision = described_class.classify(error)
+
+      expect(decision).to have_attributes(
+        status: 422,
+        code: 'EXTRACTION_EMPTY',
+        kind: 'input',
+        cacheable: true
+      )
+      expect(decision.message).to include('could not extract feed items')
+    end
+
+    it 'returns nil for unrelated errors' do
+      expect(described_class.classify(StandardError.new('boom'))).to be_nil
+    end
+  end
+
+  describe '.error_chain' do
+    it 'walks causes without looping on cycles' do
+      first = StandardError.new('first')
+      second = StandardError.new('second')
+      allow(first).to receive(:cause).and_return(second)
+      allow(second).to receive(:cause).and_return(first)
+
+      expect(described_class.error_chain(first)).to eq([first, second])
+    end
+  end
+end

--- a/spec/html2rss/web/error_responder_spec.rb
+++ b/spec/html2rss/web/error_responder_spec.rb
@@ -188,13 +188,15 @@ RSpec.describe Html2rss::Web::ErrorResponder do
 
   # @return [Hash{String=>Object}]
   def extraction_empty_error_fields
+    decision = Html2rss::Web::ErrorClassifier::EXTRACTION_EMPTY
+
     {
-      'code' => Html2rss::Web::ErrorClassifier::EXTRACTION_EMPTY_CODE,
-      'message' => Html2rss::Web::ErrorClassifier::EXTRACTION_EMPTY_MESSAGE,
-      'kind' => 'input',
-      'retryable' => false,
-      'next_action' => 'correct_input',
-      'retry_action' => 'none'
+      'code' => decision.code,
+      'message' => decision.message,
+      'kind' => decision.kind,
+      'retryable' => decision.retryable,
+      'next_action' => decision.next_action,
+      'retry_action' => decision.retry_action
     }
   end
 end

--- a/spec/html2rss/web/error_responder_spec.rb
+++ b/spec/html2rss/web/error_responder_spec.rb
@@ -189,8 +189,8 @@ RSpec.describe Html2rss::Web::ErrorResponder do
   # @return [Hash{String=>Object}]
   def extraction_empty_error_fields
     {
-      'code' => Html2rss::Web::ErrorResponder::EXTRACTION_EMPTY_CODE,
-      'message' => Html2rss::Web::ErrorResponder::EXTRACTION_EMPTY_MESSAGE,
+      'code' => Html2rss::Web::ErrorClassifier::EXTRACTION_EMPTY_CODE,
+      'message' => Html2rss::Web::ErrorClassifier::EXTRACTION_EMPTY_MESSAGE,
       'kind' => 'input',
       'retryable' => false,
       'next_action' => 'correct_input',

--- a/spec/html2rss/web/feed_token_spec.rb
+++ b/spec/html2rss/web/feed_token_spec.rb
@@ -1,101 +1,122 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require_relative '../../../app/web/security/feed_token'
-require_relative '../../../app/web/security/url_validator'
+require_relative '../../../app'
 
 RSpec.describe Html2rss::Web::FeedToken do
-  describe '.create_with_validation' do
-    it 'creates a valid feed token' do
-      token = described_class.create_with_validation(
-        username: 'alice',
-        url: 'https://example.com/feed',
-        secret_key: 'test-secret',
-        strategy: 'some_strategy'
-      )
+  describe Html2rss::Web::FeedToken::Signer do
+    describe '.create' do
+      it 'creates a valid feed token' do
+        token = described_class.create(
+          username: 'alice',
+          url: 'https://example.com/feed',
+          secret_key: 'test-secret',
+          strategy: 'some_strategy'
+        )
 
-      expect(token).to be_a(described_class)
-      expect(token.username).to eq('alice')
+        expect(token).to be_a(Html2rss::Web::FeedToken)
+        expect(token.username).to eq('alice')
+      end
+
+      it 'stores the normalized attributes' do
+        token = described_class.create(
+          username: 'alice',
+          url: 'https://example.com/feed',
+          secret_key: 'test-secret',
+          strategy: 'some_strategy'
+        )
+
+        expect(token.url).to eq('https://example.com/feed')
+        expect(token.strategy).to eq('some_strategy')
+      end
+
+      it 'signs the token' do
+        token = described_class.create(
+          username: 'alice',
+          url: 'https://example.com/feed',
+          secret_key: 'test-secret',
+          strategy: 'some_strategy'
+        )
+
+        expect(token.signature).not_to be_nil
+      end
+
+      it 'returns nil for invalid username' do
+        token = described_class.create(
+          username: '',
+          url: 'https://example.com/feed',
+          secret_key: 'test-secret'
+        )
+
+        expect(token).to be_nil
+      end
+
+      it 'returns nil for invalid url' do
+        token = described_class.create(
+          username: 'alice',
+          url: 'not-a-url',
+          secret_key: 'test-secret'
+        )
+
+        expect(token).to be_nil
+      end
     end
 
-    it 'stores the normalized attributes' do
-      token = described_class.create_with_validation(
-        username: 'alice',
-        url: 'https://example.com/feed',
-        secret_key: 'test-secret',
-        strategy: 'some_strategy'
-      )
+    describe '.validate' do
+      let(:secret_key) { 'test-secret' }
+      let(:url) { 'https://example.com/feed' }
+      let(:token) do
+        described_class.create(
+          username: 'alice',
+          url:,
+          secret_key:,
+          strategy: 'some_strategy'
+        )
+      end
 
-      expect(token.url).to eq('https://example.com/feed')
-      expect(token.strategy).to eq('some_strategy')
+      it 'returns the token when valid' do
+        encoded = Html2rss::Web::FeedToken::Codec.encode(token)
+
+        expect(described_class.validate(encoded, url, secret_key)).to eq(token)
+      end
+
+      it 'returns nil for wrong url' do
+        encoded = Html2rss::Web::FeedToken::Codec.encode(token)
+
+        expect(described_class.validate(encoded, 'https://different.com', secret_key)).to be_nil
+      end
+
+      it 'returns nil for wrong secret' do
+        encoded = Html2rss::Web::FeedToken::Codec.encode(token)
+
+        expect(described_class.validate(encoded, url, 'wrong-secret')).to be_nil
+      end
+
+      it 'returns nil for expired tokens' do
+        expired = described_class.create(username: 'alice', url:, secret_key:, expires_in: -10)
+        encoded = Html2rss::Web::FeedToken::Codec.encode(expired)
+
+        expect(described_class.validate(encoded, url, secret_key)).to be_nil
+      end
     end
 
-    it 'signs the token' do
-      token = described_class.create_with_validation(
-        username: 'alice',
-        url: 'https://example.com/feed',
-        secret_key: 'test-secret',
-        strategy: 'some_strategy'
-      )
+    describe '.valid_signature?' do
+      it 'checks the signature against the payload' do
+        token = described_class.create(
+          username: 'alice',
+          url: 'https://example.com/feed',
+          secret_key: 'test-secret'
+        )
 
-      expect(token.signature).not_to be_nil
-    end
-
-    it 'returns nil for invalid username' do
-      token = described_class.create_with_validation(
-        username: '',
-        url: 'https://example.com/feed',
-        secret_key: 'test-secret'
-      )
-
-      expect(token).to be_nil
-    end
-
-    it 'returns nil for invalid url' do
-      token = described_class.create_with_validation(
-        username: 'alice',
-        url: 'not-a-url',
-        secret_key: 'test-secret'
-      )
-
-      expect(token).to be_nil
+        expect(described_class.valid_signature?(token, 'test-secret')).to be(true)
+        expect(described_class.valid_signature?(token, 'wrong-secret')).to be(false)
+      end
     end
   end
 
-  describe '.validate_and_decode' do
-    let(:secret_key) { 'test-secret' }
-    let(:url) { 'https://example.com/feed' }
+  describe Html2rss::Web::FeedToken::Codec do
     let(:token) do
-      described_class.create_with_validation(
-        username: 'alice',
-        url:,
-        secret_key:,
-        strategy: 'some_strategy'
-      )
-    end
-
-    it 'returns the token when valid' do
-      expect(described_class.validate_and_decode(token.encode, url, secret_key)).to eq(token)
-    end
-
-    it 'returns nil for wrong url' do
-      expect(described_class.validate_and_decode(token.encode, 'https://different.com', secret_key)).to be_nil
-    end
-
-    it 'returns nil for wrong secret' do
-      expect(described_class.validate_and_decode(token.encode, url, 'wrong-secret')).to be_nil
-    end
-
-    it 'returns nil for expired tokens' do
-      expired = described_class.create_with_validation(username: 'alice', url:, secret_key:, expires_in: -10)
-
-      expect(described_class.validate_and_decode(expired.encode, url, secret_key)).to be_nil
-    end
-  end
-
-  describe '.decode' do
-    let(:token) do
-      described_class.create_with_validation(
+      Html2rss::Web::FeedToken::Signer.create(
         username: 'alice',
         url: 'https://example.com/feed',
         secret_key: 'test-secret',
@@ -103,16 +124,31 @@ RSpec.describe Html2rss::Web::FeedToken do
       )
     end
 
-    it 'decodes valid payloads' do
-      expect(described_class.decode(token.encode)).to eq(token)
+    describe '.decode' do
+      it 'decodes valid payloads' do
+        expect(described_class.decode(described_class.encode(token))).to eq(token)
+      end
+
+      it 'rejects invalid strings' do
+        expect(described_class.decode('invalid')).to be_nil
+      end
+
+      it 'rejects nil payloads' do
+        expect(described_class.decode(nil)).to be_nil
+      end
     end
 
-    it 'rejects invalid strings' do
-      expect(described_class.decode('invalid')).to be_nil
-    end
+    describe 'wire format compatibility' do
+      it 'round-trips zlib+base64 JSON with p/s and u/l/e/t keys' do
+        encoded = described_class.encode(token)
+        inflated = Zlib::Inflate.inflate(Base64.urlsafe_decode64(encoded))
+        document = JSON.parse(inflated, symbolize_names: true)
 
-    it 'rejects nil payloads' do
-      expect(described_class.decode(nil)).to be_nil
+        expect(document.keys).to contain_exactly(:p, :s)
+        expect(document[:p]).to include(u: 'alice', l: 'https://example.com/feed', t: 'some_strategy')
+        expect(document[:p]).to have_key(:e)
+        expect(document[:s]).to eq(token.signature)
+      end
     end
   end
 
@@ -127,19 +163,6 @@ RSpec.describe Html2rss::Web::FeedToken do
       token = described_class.new('alice', 'https://example.com/feed', Time.now.to_i + 3600, 'sig', nil)
 
       expect(token.expired?).to be(false)
-    end
-  end
-
-  describe '#valid_signature?' do
-    it 'checks the signature against the payload' do
-      token = described_class.create_with_validation(
-        username: 'alice',
-        url: 'https://example.com/feed',
-        secret_key: 'test-secret'
-      )
-
-      expect(token.valid_signature?('test-secret')).to be(true)
-      expect(token.valid_signature?('wrong-secret')).to be(false)
     end
   end
 end

--- a/spec/html2rss/web/feed_token_spec.rb
+++ b/spec/html2rss/web/feed_token_spec.rb
@@ -100,6 +100,41 @@ RSpec.describe Html2rss::Web::FeedToken do
       end
     end
 
+    describe '.validate_decoded' do
+      let(:secret_key) { 'test-secret' }
+      let(:url) { 'https://example.com/feed' }
+      let(:token) do
+        described_class.create(
+          username: 'alice',
+          url:,
+          secret_key:,
+          strategy: 'some_strategy'
+        )
+      end
+
+      it 'returns the token when signature, url, and expiry are valid' do
+        expect(described_class.validate_decoded(token, url, secret_key)).to eq(token)
+      end
+
+      it 'returns nil for wrong url' do
+        expect(described_class.validate_decoded(token, 'https://different.com', secret_key)).to be_nil
+      end
+
+      it 'returns nil for wrong secret' do
+        expect(described_class.validate_decoded(token, url, 'wrong-secret')).to be_nil
+      end
+
+      it 'returns nil for expired tokens' do
+        expired = described_class.create(username: 'alice', url:, secret_key:, expires_in: -10)
+
+        expect(described_class.validate_decoded(expired, url, secret_key)).to be_nil
+      end
+
+      it 'returns nil when token is nil' do
+        expect(described_class.validate_decoded(nil, url, secret_key)).to be_nil
+      end
+    end
+
     describe '.valid_signature?' do
       it 'checks the signature against the payload' do
         token = described_class.create(

--- a/spec/html2rss/web/feed_token_spec.rb
+++ b/spec/html2rss/web/feed_token_spec.rb
@@ -171,6 +171,22 @@ RSpec.describe Html2rss::Web::FeedToken do
       it 'rejects nil payloads' do
         expect(described_class.decode(nil)).to be_nil
       end
+
+      it 'rejects payloads with incorrect types', :aggregate_failures do
+        invalid_payloads = [
+          { u: 'alice', l: 'https://example.com/feed', e: '123456' },
+          { u: 123, l: 'https://example.com/feed', e: 123_456 },
+          { u: 'alice', l: 123, e: 123_456 },
+          { u: 'alice', l: 'https://example.com/feed', e: 123_456, t: 123 }
+        ]
+
+        invalid_payloads.each do |payload|
+          bad_token = Base64.urlsafe_encode64(
+            Zlib::Deflate.deflate({ p: payload, s: 'sig' }.to_json)
+          )
+          expect(described_class.decode(bad_token)).to be_nil
+        end
+      end
     end
 
     describe 'wire format compatibility' do

--- a/spec/html2rss/web/feed_token_spec.rb
+++ b/spec/html2rss/web/feed_token_spec.rb
@@ -145,9 +145,10 @@ RSpec.describe Html2rss::Web::FeedToken do
         document = JSON.parse(inflated, symbolize_names: true)
 
         expect(document.keys).to contain_exactly(:p, :s)
-        expect(document[:p]).to include(u: 'alice', l: 'https://example.com/feed', t: 'some_strategy')
-        expect(document[:p]).to have_key(:e)
-        expect(document[:s]).to eq(token.signature)
+        expect(document).to include(
+          p: a_hash_including(u: 'alice', l: 'https://example.com/feed', t: 'some_strategy', e: kind_of(Integer)),
+          s: token.signature
+        )
       end
     end
   end

--- a/spec/html2rss/web/feeds/service_spec.rb
+++ b/spec/html2rss/web/feeds/service_spec.rb
@@ -152,5 +152,18 @@ RSpec.describe Html2rss::Web::Feeds::Service do
 
       expect(Html2rss).to have_received(:feed).once
     end
+
+    it 'maps NoFeedItemsExtracted nested in Exception#cause to empty extraction' do
+      root = no_feed_items_extracted_class.new(
+        attempts: [{ strategy: :faraday, items_count: 0, error_class: nil }]
+      )
+      wrapper = StandardError.new('strategy failed')
+      allow(wrapper).to receive(:cause).and_return(root)
+      allow(Html2rss).to receive(:feed).with(resolved_source.generator_input).and_raise(wrapper)
+
+      expect(result.status).to eq(:empty)
+      expect(result.error_kind).to eq(:extraction_empty)
+    end
   end
 end
+

--- a/spec/html2rss/web/feeds/service_spec.rb
+++ b/spec/html2rss/web/feeds/service_spec.rb
@@ -165,4 +165,28 @@ RSpec.describe Html2rss::Web::Feeds::Service do
       expect(result.error_kind).to eq(:extraction_empty)
     end
   end
+
+  context 'when a classified decision is not cacheable' do
+    before do
+      allow(Html2rss).to receive(:feed).with(resolved_source.generator_input)
+                                       .and_raise(StandardError, 'classified boom')
+      allow(Html2rss::Web::ErrorClassifier).to receive(:classify).and_return(
+        Html2rss::Web::ErrorClassifier::Decision.new(
+          status: 422,
+          code: 'NON_CACHEABLE',
+          message: 'classified but not cacheable',
+          kind: 'input',
+          cacheable: false
+        )
+      )
+    end
+
+    it 'marks the result as an error instead of empty' do
+      expect(result.status).to eq(:error)
+    end
+
+    it 'does not treat the failure as extraction_empty' do
+      expect(result.error_kind).to be_nil
+    end
+  end
 end

--- a/spec/html2rss/web/feeds/service_spec.rb
+++ b/spec/html2rss/web/feeds/service_spec.rb
@@ -176,7 +176,10 @@ RSpec.describe Html2rss::Web::Feeds::Service do
           code: 'NON_CACHEABLE',
           message: 'classified but not cacheable',
           kind: 'input',
-          cacheable: false
+          cacheable: false,
+          retryable: false,
+          next_action: 'correct_input',
+          retry_action: 'none'
         )
       )
     end

--- a/spec/html2rss/web/feeds/service_spec.rb
+++ b/spec/html2rss/web/feeds/service_spec.rb
@@ -166,4 +166,3 @@ RSpec.describe Html2rss::Web::Feeds::Service do
     end
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ if (ENV.fetch('CI', nil) || ENV.fetch('COVERAGE', nil)) && ENV['RUN_DOCKER_SPECS
     track_files '**/*.rb'
 
     minimum_coverage 80 unless ENV['OPENAPI']
-    maximum_coverage_drop 5
+    maximum_coverage_drop 5 unless ENV['OPENAPI']
   end
 end
 


### PR DESCRIPTION
## Summary
- Extract feed-conversion policy out of `useFeedConversion` into pure modules (`feedsApi`, `feedCreationError`, `previewHydration`, `shared`), with preview status nested on `CreatedFeedResult`.
- Unify App/panels onto one discriminated `AppViewModel` (`create | submitting | token_prompt | result | error`), removing parallel shell/preview workflow-state props.
- Centralize extraction-empty HTTP decisions in `ErrorClassifier` (`status`/`code`/`message`/`kind`/`cacheable`); `Feeds::Service` and `ErrorResponder` consume it instead of duplicating cause walks.
- Split `FeedToken` into a pure value object plus `Codec` and `Signer`; wire format and HMAC payload stay bit-compatible (no backcompat shims).
- Gate hygiene: RuboCop/ESLint/Prettier on new surfaces; skip SimpleCov coverage-drop during OpenAPI-only RSpec.

## Test plan
- [x] `make ready` (Dev Container)
- [x] `make yard-verify-public-docs`
- [x] `make ci-ready` (OpenAPI verify + frontend e2e smoke)
- [ ] Manual smoke at `http://127.0.0.1:4001/` — create / token prompt / result state parity