### PR TITLE
fix(auto_source): pin request budget for token-based auto-source feeds

### DIFF
--- a/app/web/feeds/source_resolver.rb
+++ b/app/web/feeds/source_resolver.rb
@@ -8,9 +8,7 @@ module Html2rss
       ##
       # Resolves static and token-backed requests into shared generator inputs.
       module SourceResolver
-        # Request budget for token-backed auto-source feeds. Matches the
-        # max_requests default applied by Html2rss.auto_source so that sitemap
-        # sub-fetches are not silently blocked by Policy::DEFAULTS[:max_requests]=1.
+        # Request budget for token-backed auto-source feeds
         AUTO_SOURCE_MAX_REQUESTS = 4
 
         class << self

--- a/app/web/feeds/source_resolver.rb
+++ b/app/web/feeds/source_resolver.rb
@@ -8,6 +8,11 @@ module Html2rss
       ##
       # Resolves static and token-backed requests into shared generator inputs.
       module SourceResolver
+        # Request budget for token-backed auto-source feeds. Matches the
+        # max_requests default applied by Html2rss.auto_source so that sitemap
+        # sub-fetches are not silently blocked by Policy::DEFAULTS[:max_requests]=1.
+        AUTO_SOURCE_MAX_REQUESTS = 4
+
         class << self
           # @param feed_request [Html2rss::Web::Feeds::Contracts::Request]
           # @return [Html2rss::Web::Feeds::Contracts::ResolvedSource]
@@ -128,7 +133,12 @@ module Html2rss
           def token_generator_input(url, strategy)
             global_config = LocalConfig.global
             base_input = global_config.slice(:stylesheets, :headers)
-            base_input.merge(channel: { url: url }, auto_source: {}, strategy: strategy.to_sym)
+            base_input.merge(
+              channel: { url: url },
+              auto_source: {},
+              strategy: strategy.to_sym,
+              request: { max_requests: AUTO_SOURCE_MAX_REQUESTS }
+            )
           end
 
           # @return [String]


### PR DESCRIPTION
html2rss-web calls Html2rss.feed (not Html2rss.auto_source), so the gem method-level max_requests default of 4 does not apply here. Without this change, token-backed auto-source feeds inherit Policy::DEFAULTS[:max_requests]=1, blocking sitemap sub-fetches. Pins max_requests=4 explicitly in token_generator_input. No breaking change.